### PR TITLE
LogicalOr and LogicalAnd expression builders renamed to Or and And

### DIFF
--- a/Linq2Shadow/QueryTranslators/Where/WhereQueryTranslator.cs
+++ b/Linq2Shadow/QueryTranslators/Where/WhereQueryTranslator.cs
@@ -322,7 +322,7 @@ namespace Linq2Shadow.QueryTranslators.Where
 
             if (typedLambdas.Any())
             {
-                var exp = ExpressionBuilders.Predicates.LogicalAnd(typedLambdas.ToArray());
+                var exp = ExpressionBuilders.Predicates.And(typedLambdas.ToArray());
                 Visit(exp);
             }
 

--- a/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs
+++ b/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs
@@ -1496,7 +1496,7 @@ namespace Linq2Shadow.Utils
 
             #endregion less than or equal
 
-            #region logical and
+            #region and
 
             /// <summary>
             /// Build the logical expression based on the AND operator.
@@ -1505,7 +1505,7 @@ namespace Linq2Shadow.Utils
             /// <returns>Builded predicate.</returns>
             /// <exception cref="ArgumentNullException">Will throw when <paramref name="predicates"/> is null.</exception>
             /// <exception cref="ArgumentException">Will throw when any operand of <paramref name="predicates"/> is null.</exception>
-            public static Expression<Func<ShadowRow, bool>> LogicalAnd(Expression<Func<ShadowRow, bool>>[] predicates)
+            public static Expression<Func<ShadowRow, bool>> And(Expression<Func<ShadowRow, bool>>[] predicates)
             {
                 ExHelpers.ThrowIfNull(() => predicates);
                 ExHelpers.ThrowIfOneOfItemsIsNull(() => predicates);
@@ -1515,7 +1515,7 @@ namespace Linq2Shadow.Utils
                 var result = predicates[0];
                 foreach (var expression in predicates.Skip(1))
                 {
-                    result = LogicalAnd(result, expression);
+                    result = And(result, expression);
                 }
 
                 return result;
@@ -1528,7 +1528,7 @@ namespace Linq2Shadow.Utils
             /// <param name="right">Right operand.</param>
             /// <returns>Builded predicate.</returns>
             /// <exception cref="ArgumentNullException">Will throw when any operand is null.</exception>
-            public static Expression<Func<ShadowRow, bool>> LogicalAnd(Expression<Func<ShadowRow, bool>> left,
+            public static Expression<Func<ShadowRow, bool>> And(Expression<Func<ShadowRow, bool>> left,
                                         Expression<Func<ShadowRow, bool>> right)
             {
                 ExHelpers.ThrowIfNull(() => left);
@@ -1540,9 +1540,9 @@ namespace Linq2Shadow.Utils
                 return lambda;
             }
 
-            #endregion logical and
+            #endregion and
 
-            #region logical or
+            #region or
 
             /// <summary>
             /// Build the logical expression based on the OR operator.
@@ -1551,7 +1551,7 @@ namespace Linq2Shadow.Utils
             /// <returns>Builded predicate.</returns>
             /// <exception cref="ArgumentNullException">Will throw when <paramref name="predicates"/> is null.</exception>
             /// <exception cref="ArgumentException">Will throw when any operand of <paramref name="predicates"/> is null.</exception>
-            public static Expression<Func<ShadowRow, bool>> LogicalOr(Expression<Func<ShadowRow, bool>>[] predicates)
+            public static Expression<Func<ShadowRow, bool>> Or(Expression<Func<ShadowRow, bool>>[] predicates)
             {
                 ExHelpers.ThrowIfNull(() => predicates);
                 ExHelpers.ThrowIfOneOfItemsIsNull(() => predicates);
@@ -1561,7 +1561,7 @@ namespace Linq2Shadow.Utils
                 var result = predicates[0];
                 foreach (var expression in predicates.Skip(1))
                 {
-                    result = LogicalOr(result, expression);
+                    result = Or(result, expression);
                 }
 
                 return result;
@@ -1574,7 +1574,7 @@ namespace Linq2Shadow.Utils
             /// <param name="right">Right operand.</param>
             /// <returns>Builded predicate.</returns>
             /// <exception cref="ArgumentNullException">Will throw when any operand is null.</exception>
-            public static Expression<Func<ShadowRow, bool>> LogicalOr(Expression<Func<ShadowRow, bool>> left,
+            public static Expression<Func<ShadowRow, bool>> Or(Expression<Func<ShadowRow, bool>> left,
                 Expression<Func<ShadowRow, bool>> right)
             {
                 ExHelpers.ThrowIfNull(() => left);
@@ -1587,7 +1587,7 @@ namespace Linq2Shadow.Utils
                 return lambda;
             }
 
-            #endregion logical or
+            #endregion or
         }
     }
 }

--- a/Linq2ShadowTests/QueryToTableTests/QueryToTable_ToCollectionTests.cs
+++ b/Linq2ShadowTests/QueryToTableTests/QueryToTable_ToCollectionTests.cs
@@ -460,12 +460,12 @@ namespace Linq2ShadowTests.QueryToTableTests
         }
 
         [Test]
-        public void Should_GroupPredicates_When_LogicalAndOperatorIsApplied()
+        public void Should_GroupPredicates_When_AndOperatorIsApplied()
         {
             // Act
             var userDzianisFound = _sut.QueryToTable(DbConfig.DbObjectNames.UsersTable)
                 .Where(
-                    ExpressionBuilders.Predicates.LogicalAnd(
+                    ExpressionBuilders.Predicates.And(
                         ExpressionBuilders.Predicates.AreEquals("Id", 0),
                         ExpressionBuilders.Predicates.AreEquals("UserName", "Dzianis")
                     )
@@ -474,7 +474,7 @@ namespace Linq2ShadowTests.QueryToTableTests
 
             var noUserFound = _sut.QueryToTable(DbConfig.DbObjectNames.UsersTable)
                 .Where(
-                    ExpressionBuilders.Predicates.LogicalAnd(
+                    ExpressionBuilders.Predicates.And(
                         ExpressionBuilders.Predicates.AreEquals("Id", 1),
                         ExpressionBuilders.Predicates.AreEquals("UserName", "Dzianis")
                     )
@@ -489,7 +489,7 @@ namespace Linq2ShadowTests.QueryToTableTests
 
             Assert.Throws<ArgumentNullException>(() =>
             {
-                ExpressionBuilders.Predicates.LogicalAnd(
+                ExpressionBuilders.Predicates.And(
                     null,
                     ExpressionBuilders.Predicates.AreEquals("UserName", "Dzianis")
                 );
@@ -497,17 +497,17 @@ namespace Linq2ShadowTests.QueryToTableTests
 
             Assert.Throws<ArgumentNullException>(() =>
             {
-                ExpressionBuilders.Predicates.LogicalAnd(
+                ExpressionBuilders.Predicates.And(
                     ExpressionBuilders.Predicates.AreEquals("UserName", "Dzianis"),
                     null
                 );
             });
 
-            Assert.Throws<ArgumentNullException>(() => ExpressionBuilders.Predicates.LogicalAnd(null));
+            Assert.Throws<ArgumentNullException>(() => ExpressionBuilders.Predicates.And(null));
 
             Assert.Throws<ArgumentException>(() =>
             {
-                ExpressionBuilders.Predicates.LogicalAnd(
+                ExpressionBuilders.Predicates.And(
                     new[]
                     {
                         ExpressionBuilders.Predicates.AreEquals("UserName", "Dzianis"),
@@ -518,12 +518,12 @@ namespace Linq2ShadowTests.QueryToTableTests
         }
 
         [Test]
-        public void Should_GroupPredicates_When_LogicalOrOperatorIsApplied()
+        public void Should_GroupPredicates_When_OrOperatorIsApplied()
         {
             // Act
             var usersDzianisAndAlexFound = _sut.QueryToTable(DbConfig.DbObjectNames.UsersTable)
                 .Where(
-                    ExpressionBuilders.Predicates.LogicalOr(
+                    ExpressionBuilders.Predicates.Or(
                         ExpressionBuilders.Predicates.AreEquals("Id", 0),
                         ExpressionBuilders.Predicates.AreEquals("UserName", "Alex")
                     )
@@ -532,7 +532,7 @@ namespace Linq2ShadowTests.QueryToTableTests
 
             var noUserFound = _sut.QueryToTable(DbConfig.DbObjectNames.UsersTable)
                 .Where(
-                    ExpressionBuilders.Predicates.LogicalOr(
+                    ExpressionBuilders.Predicates.Or(
                         ExpressionBuilders.Predicates.AreEquals("Id", -1),
                         ExpressionBuilders.Predicates.AreEquals("UserName", "Dzianis0")
                     )
@@ -547,7 +547,7 @@ namespace Linq2ShadowTests.QueryToTableTests
 
             Assert.Throws<ArgumentNullException>(() =>
             {
-                ExpressionBuilders.Predicates.LogicalOr(
+                ExpressionBuilders.Predicates.Or(
                     null,
                     ExpressionBuilders.Predicates.AreEquals("UserName", "Dzianis")
                 );
@@ -555,17 +555,17 @@ namespace Linq2ShadowTests.QueryToTableTests
 
             Assert.Throws<ArgumentNullException>(() =>
             {
-                ExpressionBuilders.Predicates.LogicalOr(
+                ExpressionBuilders.Predicates.Or(
                     ExpressionBuilders.Predicates.AreEquals("UserName", "Dzianis"),
                     null
                 );
             });
 
-            Assert.Throws<ArgumentNullException>(() => ExpressionBuilders.Predicates.LogicalOr(null));
+            Assert.Throws<ArgumentNullException>(() => ExpressionBuilders.Predicates.Or(null));
 
             Assert.Throws<ArgumentException>(() =>
             {
-                ExpressionBuilders.Predicates.LogicalOr(
+                ExpressionBuilders.Predicates.Or(
                     new[]
                     {
                         ExpressionBuilders.Predicates.AreEquals("UserName", "Dzianis"),

--- a/doc_templates/get-started/get-started.md
+++ b/doc_templates/get-started/get-started.md
@@ -4,38 +4,44 @@
 > In all samples we will use database client from the **System.Data.SqlClient** package. For more about engines support, see [compatibility page](/compatibility).
 
 ## Project preparing
+
 ### Creating project via dotnet CLI
+
 ```cmd
 dotnet new console -n SampleApp
 cd SampleApp
 ```
 
 ### Install Linq2Shadow package
+
 ```cmd
 dotnet add SampleApp package Linq2Shadow
 ```
 
 ### Install database client package
+
 ```cmd
 dotnet add . package System.Data.SqlClient
 ```
 
 ## DatabaseContext
+
 The DatabaseContext object present the context over pure connection to make query operations(for example: query to table, view, stored procedure, function and etc.). For more info about DatabaseContext, see [API](/api/Linq2Shadow.DatabaseContext.html).
 
 > [!NOTE]
-> SqlServer connection string is not defined in here code. We will use  connection string from [attachments](attachments.html#connection-string).
+> SqlServer connection string is not defined in here code. We will use connection string from [attachments](attachments.html#connection-string).
 
 Instantiating the DatabaseContext object:
 
 ```csharp
-Func<SqlConnection> connectionFactory = () => new SqlConnection(connectionString);  
+Func<SqlConnection> connectionFactory = () => new SqlConnection(connectionString);
 var db = new DatabaseContext(connectionFactory);
 ```
 
 ## ShadowRow
 
 Try execute this code:
+
 ```csharp
 ShadowRow userFound = db.QueryToTable("tUsers").First();
 ```
@@ -43,6 +49,7 @@ ShadowRow userFound = db.QueryToTable("tUsers").First();
 As you can see, that the result of query is the ShadowRow object. The The ShadowRow is needed to present the entry retrieved from query. We can don't know table name(and entity structure also) at compilation time, because data source can be passed from the client or 3rd-party service, for example.
 
 Example to get property of entry:
+
 ```csharp
 string uname = userFound["UserName"]; // "Dzianis"
 dynamic userDynamic = userFound;
@@ -54,44 +61,51 @@ int countOfProperties = userFound.Count; // 1
 IEnumerable<string> propertyNames = userFound.Keys; // ["UserName", "Married"]
 ```
 
-##  Query examples
->[!NOTE]
+## Query examples
+
+> [!NOTE]
 > In those samples will be used DatabaseContext object created at above.
 
 # [Query to table](#tab/quey-to-table)
+
 ```csharp
-var usersFound = db.QueryToTable("tUsers")  
+var usersFound = db.QueryToTable("tUsers")
     .ToList();
 ```
 
 # [Query to view](#tab/quey-to-view)
+
 Queries to view has the same approach as to table.
 
 # [Query to store procedure](#tab/quey-to-stored-procedure)
+
 ```csharp
-var spArgs = new Dictionary<string, object>(){ {"UserName", "Dzianis"} };  
-var usersFound = db.QueryToStoredProcedure("spFindUsers", spArgs)  
+var spArgs = new Dictionary<string, object>(){ {"UserName", "Dzianis"} };
+var usersFound = db.QueryToStoredProcedure("spFindUsers", spArgs)
     .ToList();
 
 // TODO: typed params approach
-var spArgsTyped = new { UserName = "Dzianis" };  
-var usersFoundSame = db.QueryToStoredProcedure("spFindUsers", spArgsTyped)  
+var spArgsTyped = new { UserName = "Dzianis" };
+var usersFoundSame = db.QueryToStoredProcedure("spFindUsers", spArgsTyped)
     .ToList();
 ```
 
 # [Query to function](#tab/quey-to-function)
+
 ```csharp
-var functionArguments = new object[] { "Dzianis" };  
-var usersFound = db.QueryToStoredProcedure("fFindUsers", functionArguments)  
+var functionArguments = new object[] { "Dzianis" };
+var usersFound = db.QueryToStoredProcedure("fFindUsers", functionArguments)
     .ToList();
 ```
-***
+
+---
 
 ### Paging sample
+
 ```csharp
-var userFound = db.QueryToTable("tUsers")  
-    .Skip(1)  
-    .Take(1)  
+var userFound = db.QueryToTable("tUsers")
+    .Skip(1)
+    .Take(1)
     .ToList();
 ```
 
@@ -101,19 +115,20 @@ var userFound = db.QueryToTable("tUsers")
 > More about ExpressionBuilders.Predicates class see [below](#predicates).
 
 ```csharp
-var userFound = db.QueryToTable("tUsers")  
-    .Where(ExpressionBuilders.Predicates.AreEqual("UserName", "Dzianis"))  
+var userFound = db.QueryToTable("tUsers")
+    .Where(ExpressionBuilders.Predicates.AreEqual("UserName", "Dzianis"))
     .ToList();
 ```
 
 ### Count example
+
 > [!NOTE]
 > More about ExpressionBuilders.Predicates class see [below](#predicates).
 
 ```csharp
 var countAl = db.QueryToTable("tUsers").Count();
 
-var countDzianises = db.QueryToTable("tUsers")  
+var countDzianises = db.QueryToTable("tUsers")
     .Count(ExpressionBuilders.Predicates.AreEqual("UserName", "Dzianis"));
 ```
 
@@ -123,38 +138,42 @@ var countDzianises = db.QueryToTable("tUsers")
 > Use **ExpressionBuilders.MemberAccess(string memberName)** helper to create attribute-based expression.
 
 ```csharp
-var usersOrdered = db.QueryToTable("tUsers")  
-    .OrderBy(ExpressionBuilders.MemberAccess("UserName"))  
-    .ThenByDescending(ExpressionBuilders.MemberAccess("Marrried"))  
+var usersOrdered = db.QueryToTable("tUsers")
+    .OrderBy(ExpressionBuilders.MemberAccess("UserName"))
+    .ThenByDescending(ExpressionBuilders.MemberAccess("Marrried"))
     .ToList();
 ```
 
 ### First example
+
 ```csharp
 var firstFound = db.QueryToTable("tUsers")
     .First(); // or FirstOrDefault()
 ```
 
 ### Reading via loop
+
 ```csharp
-// All data are not loaded to memory, here.  
-// Data reads like `from row to row`: EnumeratorObj.Move() initiate DbDataReader.Read()  
-foreach(var row in db.QueryToTable("tUsers"))  
-{  
+// All data are not loaded to memory, here.
+// Data reads like `from row to row`: EnumeratorObj.Move() initiate DbDataReader.Read()
+foreach(var row in db.QueryToTable("tUsers"))
+{
     Console.WriteLine(row["UserName"]);
 }
 ```
 
 ### Select example
+
 ```csharp
-var usersFound = db.QueryToTable("tUsers")  
-    .SelectOnly(new [] { "Married" })  
+var usersFound = db.QueryToTable("tUsers")
+    .SelectOnly(new [] { "Married" })
     .First();
 // Output: [0]
 // !Attention!: UserName is skipped
 ```
 
 ### Async example
+
 ```csharp
 await db.QueryToTable("tUsers").ToListAsync();
 await db.QueryToTable("tUsers").FirstAsync();
@@ -194,13 +213,13 @@ ExpressionBuilders.Predicates.LessThan("Age", 1);
 ExpressionBuilders.Predicates.LessThanOrEqual("Age", 1);
 
 // SQL equivalent:  `Age > 1 AND Age < 2`
-ExpressionBuilders.Predicates.LogicalAnd(
+ExpressionBuilders.Predicates.And(
     ExpressionBuilders.Predicates.GreaterThan("Age", 1),
     ExpressionBuilders.Predicates.LessThan("Age", 2)
 );
 
 // SQL equivalent:  `Age = 1 OR Age = 2`
-ExpressionBuilders.Predicates.LogicalOr(
+ExpressionBuilders.Predicates.Or(
     ExpressionBuilders.Predicates.AreEquals("Age", 1),
     ExpressionBuilders.Predicates.AreEquals("Age", 2)
 );
@@ -215,25 +234,25 @@ ExpressionBuilders.Predicates.StringEndsWith("UserName", "Dzi");
 ExpressionBuilders.Predicates.StringStartsWith("UserName", "Dzi");
 ```
 
-##  Update source
+## Update source
 
 Approaches to update data source:
 
 ```csharp
-var updateMap = new Dictionary<string, object>(){{"UserName", "SuperDzianis"}};  
-var updatePredicate = ExpressionBuiders.Predicates.AreEquals("UserName", "Dzianis");  
+var updateMap = new Dictionary<string, object>(){{"UserName", "SuperDzianis"}};
+var updatePredicate = ExpressionBuiders.Predicates.AreEquals("UserName", "Dzianis");
 
-// update all rows  
-var udpdatedUsersCount = db.Update("tUsers", updateMap);  
+// update all rows
+var udpdatedUsersCount = db.Update("tUsers", updateMap);
 
 // update with predicate(part of data)
-var udpdatedUsersCount = db.Update("tUsers", updateMap, updatePredicate);  
+var udpdatedUsersCount = db.Update("tUsers", updateMap, updatePredicate);
 
 // same with typed model
-var udpdatedUsersCount = db.Update("tUsers", new { UserName="Dzianis" }, updatePredicate);  
+var udpdatedUsersCount = db.Update("tUsers", new { UserName="Dzianis" }, updatePredicate);
 
 // update asynchronously
-var udpdatedUsersCount = db.UpdateAsync("tUsers", new { UserName="Dzianis" }, CancellationToken.None);  
+var udpdatedUsersCount = db.UpdateAsync("tUsers", new { UserName="Dzianis" }, CancellationToken.None);
 ```
 
 ## Remove from source
@@ -247,5 +266,6 @@ db.Remove("tUsers");
 // Update users with 'Dzianis' UserName
 db.Remove("tUsers", ExpressionBuilders.Predicates.AreEquals("UserName", "Dzianis"));
 ```
+
 > [!NOTE]
 > Database Context object has same an asynchronous Remove overloads with **Async** postfix. Asynchronous overloads supports cancellation also.

--- a/docs/api/Linq2Shadow.DatabaseContext.html
+++ b/docs/api/Linq2Shadow.DatabaseContext.html
@@ -121,7 +121,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_DatabaseContext__ctor_System_Func_System_Data_IDbConnection__.md&amp;value=---%0Auid%3A%20Linq2Shadow.DatabaseContext.%23ctor(System.Func%7BSystem.Data.IDbConnection%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/DatabaseContext.cs/#L19">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/DatabaseContext.cs/#L19">View Source</a>
   </span>
   <a id="Linq2Shadow_DatabaseContext__ctor_" data-uid="Linq2Shadow.DatabaseContext.#ctor*"></a>
   <h4 id="Linq2Shadow_DatabaseContext__ctor_System_Func_System_Data_IDbConnection__" data-uid="Linq2Shadow.DatabaseContext.#ctor(System.Func{System.Data.IDbConnection})">DatabaseContext(Func&lt;IDbConnection&gt;)</h4>
@@ -155,7 +155,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_DatabaseContext_Dispose.md&amp;value=---%0Auid%3A%20Linq2Shadow.DatabaseContext.Dispose%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/DatabaseContext.cs/#L118">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/DatabaseContext.cs/#L118">View Source</a>
   </span>
   <a id="Linq2Shadow_DatabaseContext_Dispose_" data-uid="Linq2Shadow.DatabaseContext.Dispose*"></a>
   <h4 id="Linq2Shadow_DatabaseContext_Dispose" data-uid="Linq2Shadow.DatabaseContext.Dispose">Dispose()</h4>
@@ -170,7 +170,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_DatabaseContext_Dispose_System_Boolean_.md&amp;value=---%0Auid%3A%20Linq2Shadow.DatabaseContext.Dispose(System.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/DatabaseContext.cs/#L107">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/DatabaseContext.cs/#L107">View Source</a>
   </span>
   <a id="Linq2Shadow_DatabaseContext_Dispose_" data-uid="Linq2Shadow.DatabaseContext.Dispose*"></a>
   <h4 id="Linq2Shadow_DatabaseContext_Dispose_System_Boolean_" data-uid="Linq2Shadow.DatabaseContext.Dispose(System.Boolean)">Dispose(Boolean)</h4>
@@ -202,7 +202,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_DatabaseContext_QueryToStoredProcedure_System_String_System_Collections_Generic_IDictionary_System_String_System_Object__.md&amp;value=---%0Auid%3A%20Linq2Shadow.DatabaseContext.QueryToStoredProcedure(System.String%2CSystem.Collections.Generic.IDictionary%7BSystem.String%2CSystem.Object%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/DatabaseContext.cs/#L44">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/DatabaseContext.cs/#L44">View Source</a>
   </span>
   <a id="Linq2Shadow_DatabaseContext_QueryToStoredProcedure_" data-uid="Linq2Shadow.DatabaseContext.QueryToStoredProcedure*"></a>
   <h4 id="Linq2Shadow_DatabaseContext_QueryToStoredProcedure_System_String_System_Collections_Generic_IDictionary_System_String_System_Object__" data-uid="Linq2Shadow.DatabaseContext.QueryToStoredProcedure(System.String,System.Collections.Generic.IDictionary{System.String,System.Object})">QueryToStoredProcedure(String, IDictionary&lt;String, Object&gt;)</h4>
@@ -254,7 +254,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_DatabaseContext_QueryToStoredProcedure__1_System_String___0_.md&amp;value=---%0Auid%3A%20Linq2Shadow.DatabaseContext.QueryToStoredProcedure%60%601(System.String%2C%60%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/DatabaseContext.cs/#L49">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/DatabaseContext.cs/#L49">View Source</a>
   </span>
   <a id="Linq2Shadow_DatabaseContext_QueryToStoredProcedure_" data-uid="Linq2Shadow.DatabaseContext.QueryToStoredProcedure*"></a>
   <h4 id="Linq2Shadow_DatabaseContext_QueryToStoredProcedure__1_System_String___0_" data-uid="Linq2Shadow.DatabaseContext.QueryToStoredProcedure``1(System.String,``0)">QueryToStoredProcedure&lt;T&gt;(String, T)</h4>
@@ -323,7 +323,7 @@ public IEnumerable&lt;ShadowRow&gt; QueryToStoredProcedure&lt;T&gt;(string store
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_DatabaseContext_QueryToTable_System_String_.md&amp;value=---%0Auid%3A%20Linq2Shadow.DatabaseContext.QueryToTable(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/DatabaseContext.cs/#L100">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/DatabaseContext.cs/#L100">View Source</a>
   </span>
   <a id="Linq2Shadow_DatabaseContext_QueryToTable_" data-uid="Linq2Shadow.DatabaseContext.QueryToTable*"></a>
   <h4 id="Linq2Shadow_DatabaseContext_QueryToTable_System_String_" data-uid="Linq2Shadow.DatabaseContext.QueryToTable(System.String)">QueryToTable(String)</h4>
@@ -370,7 +370,7 @@ public IEnumerable&lt;ShadowRow&gt; QueryToStoredProcedure&lt;T&gt;(string store
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_DatabaseContext_QueryToTableValuedFunction_System_String_System_Object___.md&amp;value=---%0Auid%3A%20Linq2Shadow.DatabaseContext.QueryToTableValuedFunction(System.String%2CSystem.Object%5B%5D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/DatabaseContext.cs/#L39">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/DatabaseContext.cs/#L39">View Source</a>
   </span>
   <a id="Linq2Shadow_DatabaseContext_QueryToTableValuedFunction_" data-uid="Linq2Shadow.DatabaseContext.QueryToTableValuedFunction*"></a>
   <h4 id="Linq2Shadow_DatabaseContext_QueryToTableValuedFunction_System_String_System_Object___" data-uid="Linq2Shadow.DatabaseContext.QueryToTableValuedFunction(System.String,System.Object[])">QueryToTableValuedFunction(String, Object[])</h4>
@@ -422,7 +422,7 @@ public IEnumerable&lt;ShadowRow&gt; QueryToStoredProcedure&lt;T&gt;(string store
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_DatabaseContext_Remove_System_String_System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean___.md&amp;value=---%0Auid%3A%20Linq2Shadow.DatabaseContext.Remove(System.String%2CSystem.Linq.Expressions.Expression%7BSystem.Func%7BLinq2Shadow.ShadowRow%2CSystem.Boolean%7D%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/DatabaseContext.Remove.cs/#L51">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/DatabaseContext.Remove.cs/#L51">View Source</a>
   </span>
   <a id="Linq2Shadow_DatabaseContext_Remove_" data-uid="Linq2Shadow.DatabaseContext.Remove*"></a>
   <h4 id="Linq2Shadow_DatabaseContext_Remove_System_String_System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean___" data-uid="Linq2Shadow.DatabaseContext.Remove(System.String,System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}})">Remove(String, Expression&lt;Func&lt;ShadowRow, Boolean&gt;&gt;)</h4>
@@ -499,7 +499,7 @@ public IEnumerable&lt;ShadowRow&gt; QueryToStoredProcedure&lt;T&gt;(string store
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_DatabaseContext_RemoveAsync_System_String_System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean___System_Threading_CancellationToken_.md&amp;value=---%0Auid%3A%20Linq2Shadow.DatabaseContext.RemoveAsync(System.String%2CSystem.Linq.Expressions.Expression%7BSystem.Func%7BLinq2Shadow.ShadowRow%2CSystem.Boolean%7D%7D%2CSystem.Threading.CancellationToken)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/DatabaseContext.Remove.cs/#L31">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/DatabaseContext.Remove.cs/#L31">View Source</a>
   </span>
   <a id="Linq2Shadow_DatabaseContext_RemoveAsync_" data-uid="Linq2Shadow.DatabaseContext.RemoveAsync*"></a>
   <h4 id="Linq2Shadow_DatabaseContext_RemoveAsync_System_String_System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean___System_Threading_CancellationToken_" data-uid="Linq2Shadow.DatabaseContext.RemoveAsync(System.String,System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}},System.Threading.CancellationToken)">RemoveAsync(String, Expression&lt;Func&lt;ShadowRow, Boolean&gt;&gt;, CancellationToken)</h4>
@@ -582,7 +582,7 @@ public IEnumerable&lt;ShadowRow&gt; QueryToStoredProcedure&lt;T&gt;(string store
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_DatabaseContext_Update_System_String_System_Collections_Generic_Dictionary_System_String_System_Object__System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean___.md&amp;value=---%0Auid%3A%20Linq2Shadow.DatabaseContext.Update(System.String%2CSystem.Collections.Generic.Dictionary%7BSystem.String%2CSystem.Object%7D%2CSystem.Linq.Expressions.Expression%7BSystem.Func%7BLinq2Shadow.ShadowRow%2CSystem.Boolean%7D%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/DatabaseContext.Update.cs/#L69">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/DatabaseContext.Update.cs/#L69">View Source</a>
   </span>
   <a id="Linq2Shadow_DatabaseContext_Update_" data-uid="Linq2Shadow.DatabaseContext.Update*"></a>
   <h4 id="Linq2Shadow_DatabaseContext_Update_System_String_System_Collections_Generic_Dictionary_System_String_System_Object__System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean___" data-uid="Linq2Shadow.DatabaseContext.Update(System.String,System.Collections.Generic.Dictionary{System.String,System.Object},System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}})">Update(String, Dictionary&lt;String, Object&gt;, Expression&lt;Func&lt;ShadowRow, Boolean&gt;&gt;)</h4>
@@ -680,7 +680,7 @@ public IEnumerable&lt;ShadowRow&gt; QueryToStoredProcedure&lt;T&gt;(string store
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_DatabaseContext_Update__1_System_String___0_System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean___.md&amp;value=---%0Auid%3A%20Linq2Shadow.DatabaseContext.Update%60%601(System.String%2C%60%600%2CSystem.Linq.Expressions.Expression%7BSystem.Func%7BLinq2Shadow.ShadowRow%2CSystem.Boolean%7D%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/DatabaseContext.Update.cs/#L90">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/DatabaseContext.Update.cs/#L90">View Source</a>
   </span>
   <a id="Linq2Shadow_DatabaseContext_Update_" data-uid="Linq2Shadow.DatabaseContext.Update*"></a>
   <h4 id="Linq2Shadow_DatabaseContext_Update__1_System_String___0_System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean___" data-uid="Linq2Shadow.DatabaseContext.Update``1(System.String,``0,System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}})">Update&lt;T&gt;(String, T, Expression&lt;Func&lt;ShadowRow, Boolean&gt;&gt;)</h4>
@@ -789,7 +789,7 @@ public IEnumerable&lt;ShadowRow&gt; QueryToStoredProcedure&lt;T&gt;(string store
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_DatabaseContext_UpdateAsync_System_String_System_Collections_Generic_Dictionary_System_String_System_Object__System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean___System_Threading_CancellationToken_.md&amp;value=---%0Auid%3A%20Linq2Shadow.DatabaseContext.UpdateAsync(System.String%2CSystem.Collections.Generic.Dictionary%7BSystem.String%2CSystem.Object%7D%2CSystem.Linq.Expressions.Expression%7BSystem.Func%7BLinq2Shadow.ShadowRow%2CSystem.Boolean%7D%7D%2CSystem.Threading.CancellationToken)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/DatabaseContext.Update.cs/#L115">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/DatabaseContext.Update.cs/#L115">View Source</a>
   </span>
   <a id="Linq2Shadow_DatabaseContext_UpdateAsync_" data-uid="Linq2Shadow.DatabaseContext.UpdateAsync*"></a>
   <h4 id="Linq2Shadow_DatabaseContext_UpdateAsync_System_String_System_Collections_Generic_Dictionary_System_String_System_Object__System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean___System_Threading_CancellationToken_" data-uid="Linq2Shadow.DatabaseContext.UpdateAsync(System.String,System.Collections.Generic.Dictionary{System.String,System.Object},System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}},System.Threading.CancellationToken)">UpdateAsync(String, Dictionary&lt;String, Object&gt;, Expression&lt;Func&lt;ShadowRow, Boolean&gt;&gt;, CancellationToken)</h4>
@@ -893,7 +893,7 @@ public IEnumerable&lt;ShadowRow&gt; QueryToStoredProcedure&lt;T&gt;(string store
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_DatabaseContext_UpdateAsync__1_System_String___0_System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean___System_Threading_CancellationToken_.md&amp;value=---%0Auid%3A%20Linq2Shadow.DatabaseContext.UpdateAsync%60%601(System.String%2C%60%600%2CSystem.Linq.Expressions.Expression%7BSystem.Func%7BLinq2Shadow.ShadowRow%2CSystem.Boolean%7D%7D%2CSystem.Threading.CancellationToken)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/DatabaseContext.Update.cs/#L138">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/DatabaseContext.Update.cs/#L138">View Source</a>
   </span>
   <a id="Linq2Shadow_DatabaseContext_UpdateAsync_" data-uid="Linq2Shadow.DatabaseContext.UpdateAsync*"></a>
   <h4 id="Linq2Shadow_DatabaseContext_UpdateAsync__1_System_String___0_System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean___System_Threading_CancellationToken_" data-uid="Linq2Shadow.DatabaseContext.UpdateAsync``1(System.String,``0,System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}},System.Threading.CancellationToken)">UpdateAsync&lt;T&gt;(String, T, Expression&lt;Func&lt;ShadowRow, Boolean&gt;&gt;, CancellationToken)</h4>
@@ -1018,7 +1018,7 @@ public IEnumerable&lt;ShadowRow&gt; QueryToStoredProcedure&lt;T&gt;(string store
                     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_DatabaseContext.md&amp;value=---%0Auid%3A%20Linq2Shadow.DatabaseContext%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/DatabaseContext.Update.cs/#L14" class="contribution-link">View Source</a>
+                    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/DatabaseContext.Update.cs/#L14" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/Linq2Shadow.Extensions.QueryableAsyncExtensions.html
+++ b/docs/api/Linq2Shadow.Extensions.QueryableAsyncExtensions.html
@@ -117,7 +117,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Extensions_QueryableAsyncExtensions_ToListAsync__1_System_Linq_IQueryable___0__System_Threading_CancellationToken_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Extensions.QueryableAsyncExtensions.ToListAsync%60%601(System.Linq.IQueryable%7B%60%600%7D%2CSystem.Threading.CancellationToken)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Extensions/QueryableAsyncExtensions.cs/#L20">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Extensions/QueryableAsyncExtensions.cs/#L20">View Source</a>
   </span>
   <a id="Linq2Shadow_Extensions_QueryableAsyncExtensions_ToListAsync_" data-uid="Linq2Shadow.Extensions.QueryableAsyncExtensions.ToListAsync*"></a>
   <h4 id="Linq2Shadow_Extensions_QueryableAsyncExtensions_ToListAsync__1_System_Linq_IQueryable___0__System_Threading_CancellationToken_" data-uid="Linq2Shadow.Extensions.QueryableAsyncExtensions.ToListAsync``1(System.Linq.IQueryable{``0},System.Threading.CancellationToken)">ToListAsync&lt;T&gt;(IQueryable&lt;T&gt;, CancellationToken)</h4>
@@ -211,7 +211,7 @@
                     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Extensions_QueryableAsyncExtensions.md&amp;value=---%0Auid%3A%20Linq2Shadow.Extensions.QueryableAsyncExtensions%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Extensions/QueryableAsyncExtensions.cs/#L10" class="contribution-link">View Source</a>
+                    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Extensions/QueryableAsyncExtensions.cs/#L10" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/Linq2Shadow.Extensions.QueryableExtensions.html
+++ b/docs/api/Linq2Shadow.Extensions.QueryableExtensions.html
@@ -118,7 +118,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Extensions_QueryableExtensions_SelectOnly__1_System_Linq_IQueryable___0__System_String___.md&amp;value=---%0Auid%3A%20Linq2Shadow.Extensions.QueryableExtensions.SelectOnly%60%601(System.Linq.IQueryable%7B%60%600%7D%2CSystem.String%5B%5D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Extensions/QueryableExtensions.cs/#L23">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Extensions/QueryableExtensions.cs/#L23">View Source</a>
   </span>
   <a id="Linq2Shadow_Extensions_QueryableExtensions_SelectOnly_" data-uid="Linq2Shadow.Extensions.QueryableExtensions.SelectOnly*"></a>
   <h4 id="Linq2Shadow_Extensions_QueryableExtensions_SelectOnly__1_System_Linq_IQueryable___0__System_String___" data-uid="Linq2Shadow.Extensions.QueryableExtensions.SelectOnly``1(System.Linq.IQueryable{``0},System.String[])">SelectOnly&lt;T&gt;(IQueryable&lt;T&gt;, String[])</h4>
@@ -227,7 +227,7 @@
                     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Extensions_QueryableExtensions.md&amp;value=---%0Auid%3A%20Linq2Shadow.Extensions.QueryableExtensions%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Extensions/QueryableExtensions.cs/#L10" class="contribution-link">View Source</a>
+                    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Extensions/QueryableExtensions.cs/#L10" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/Linq2Shadow.ShadowRow.html
+++ b/docs/api/Linq2Shadow.ShadowRow.html
@@ -129,7 +129,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_ShadowRow_Count.md&amp;value=---%0Auid%3A%20Linq2Shadow.ShadowRow.Count%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/ShadowRow.cs/#L112">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/ShadowRow.cs/#L112">View Source</a>
   </span>
   <a id="Linq2Shadow_ShadowRow_Count_" data-uid="Linq2Shadow.ShadowRow.Count*"></a>
   <h4 id="Linq2Shadow_ShadowRow_Count" data-uid="Linq2Shadow.ShadowRow.Count">Count</h4>
@@ -159,7 +159,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_ShadowRow_Item_System_String_.md&amp;value=---%0Auid%3A%20Linq2Shadow.ShadowRow.Item(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/ShadowRow.cs/#L118">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/ShadowRow.cs/#L118">View Source</a>
   </span>
   <a id="Linq2Shadow_ShadowRow_Item_" data-uid="Linq2Shadow.ShadowRow.Item*"></a>
   <h4 id="Linq2Shadow_ShadowRow_Item_System_String_" data-uid="Linq2Shadow.ShadowRow.Item(System.String)">Item[String]</h4>
@@ -206,7 +206,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_ShadowRow_Keys.md&amp;value=---%0Auid%3A%20Linq2Shadow.ShadowRow.Keys%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/ShadowRow.cs/#L120">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/ShadowRow.cs/#L120">View Source</a>
   </span>
   <a id="Linq2Shadow_ShadowRow_Keys_" data-uid="Linq2Shadow.ShadowRow.Keys*"></a>
   <h4 id="Linq2Shadow_ShadowRow_Keys" data-uid="Linq2Shadow.ShadowRow.Keys">Keys</h4>
@@ -236,7 +236,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_ShadowRow_Values.md&amp;value=---%0Auid%3A%20Linq2Shadow.ShadowRow.Values%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/ShadowRow.cs/#L121">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/ShadowRow.cs/#L121">View Source</a>
   </span>
   <a id="Linq2Shadow_ShadowRow_Values_" data-uid="Linq2Shadow.ShadowRow.Values*"></a>
   <h4 id="Linq2Shadow_ShadowRow_Values" data-uid="Linq2Shadow.ShadowRow.Values">Values</h4>
@@ -268,7 +268,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_ShadowRow_ContainsKey_System_String_.md&amp;value=---%0Auid%3A%20Linq2Shadow.ShadowRow.ContainsKey(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/ShadowRow.cs/#L114">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/ShadowRow.cs/#L114">View Source</a>
   </span>
   <a id="Linq2Shadow_ShadowRow_ContainsKey_" data-uid="Linq2Shadow.ShadowRow.ContainsKey*"></a>
   <h4 id="Linq2Shadow_ShadowRow_ContainsKey_System_String_" data-uid="Linq2Shadow.ShadowRow.ContainsKey(System.String)">ContainsKey(String)</h4>
@@ -315,7 +315,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_ShadowRow_GetDynamicMemberNames.md&amp;value=---%0Auid%3A%20Linq2Shadow.ShadowRow.GetDynamicMemberNames%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/ShadowRow.cs/#L25">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/ShadowRow.cs/#L25">View Source</a>
   </span>
   <a id="Linq2Shadow_ShadowRow_GetDynamicMemberNames_" data-uid="Linq2Shadow.ShadowRow.GetDynamicMemberNames*"></a>
   <h4 id="Linq2Shadow_ShadowRow_GetDynamicMemberNames" data-uid="Linq2Shadow.ShadowRow.GetDynamicMemberNames">GetDynamicMemberNames()</h4>
@@ -347,7 +347,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_ShadowRow_GetEnumerator.md&amp;value=---%0Auid%3A%20Linq2Shadow.ShadowRow.GetEnumerator%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/ShadowRow.cs/#L109">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/ShadowRow.cs/#L109">View Source</a>
   </span>
   <a id="Linq2Shadow_ShadowRow_GetEnumerator_" data-uid="Linq2Shadow.ShadowRow.GetEnumerator*"></a>
   <h4 id="Linq2Shadow_ShadowRow_GetEnumerator" data-uid="Linq2Shadow.ShadowRow.GetEnumerator">GetEnumerator()</h4>
@@ -377,7 +377,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_ShadowRow_TryBinaryOperation_System_Dynamic_BinaryOperationBinder_System_Object_System_Object__.md&amp;value=---%0Auid%3A%20Linq2Shadow.ShadowRow.TryBinaryOperation(System.Dynamic.BinaryOperationBinder%2CSystem.Object%2CSystem.Object%40)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/ShadowRow.cs/#L30">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/ShadowRow.cs/#L30">View Source</a>
   </span>
   <a id="Linq2Shadow_ShadowRow_TryBinaryOperation_" data-uid="Linq2Shadow.ShadowRow.TryBinaryOperation*"></a>
   <h4 id="Linq2Shadow_ShadowRow_TryBinaryOperation_System_Dynamic_BinaryOperationBinder_System_Object_System_Object__" data-uid="Linq2Shadow.ShadowRow.TryBinaryOperation(System.Dynamic.BinaryOperationBinder,System.Object,System.Object@)">TryBinaryOperation(BinaryOperationBinder, Object, out Object)</h4>
@@ -436,7 +436,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_ShadowRow_TryConvert_System_Dynamic_ConvertBinder_System_Object__.md&amp;value=---%0Auid%3A%20Linq2Shadow.ShadowRow.TryConvert(System.Dynamic.ConvertBinder%2CSystem.Object%40)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/ShadowRow.cs/#L36">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/ShadowRow.cs/#L36">View Source</a>
   </span>
   <a id="Linq2Shadow_ShadowRow_TryConvert_" data-uid="Linq2Shadow.ShadowRow.TryConvert*"></a>
   <h4 id="Linq2Shadow_ShadowRow_TryConvert_System_Dynamic_ConvertBinder_System_Object__" data-uid="Linq2Shadow.ShadowRow.TryConvert(System.Dynamic.ConvertBinder,System.Object@)">TryConvert(ConvertBinder, out Object)</h4>
@@ -490,7 +490,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_ShadowRow_TryCreateInstance_System_Dynamic_CreateInstanceBinder_System_Object___System_Object__.md&amp;value=---%0Auid%3A%20Linq2Shadow.ShadowRow.TryCreateInstance(System.Dynamic.CreateInstanceBinder%2CSystem.Object%5B%5D%2CSystem.Object%40)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/ShadowRow.cs/#L42">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/ShadowRow.cs/#L42">View Source</a>
   </span>
   <a id="Linq2Shadow_ShadowRow_TryCreateInstance_" data-uid="Linq2Shadow.ShadowRow.TryCreateInstance*"></a>
   <h4 id="Linq2Shadow_ShadowRow_TryCreateInstance_System_Dynamic_CreateInstanceBinder_System_Object___System_Object__" data-uid="Linq2Shadow.ShadowRow.TryCreateInstance(System.Dynamic.CreateInstanceBinder,System.Object[],System.Object@)">TryCreateInstance(CreateInstanceBinder, Object[], out Object)</h4>
@@ -549,7 +549,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_ShadowRow_TryDeleteIndex_System_Dynamic_DeleteIndexBinder_System_Object___.md&amp;value=---%0Auid%3A%20Linq2Shadow.ShadowRow.TryDeleteIndex(System.Dynamic.DeleteIndexBinder%2CSystem.Object%5B%5D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/ShadowRow.cs/#L48">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/ShadowRow.cs/#L48">View Source</a>
   </span>
   <a id="Linq2Shadow_ShadowRow_TryDeleteIndex_" data-uid="Linq2Shadow.ShadowRow.TryDeleteIndex*"></a>
   <h4 id="Linq2Shadow_ShadowRow_TryDeleteIndex_System_Dynamic_DeleteIndexBinder_System_Object___" data-uid="Linq2Shadow.ShadowRow.TryDeleteIndex(System.Dynamic.DeleteIndexBinder,System.Object[])">TryDeleteIndex(DeleteIndexBinder, Object[])</h4>
@@ -603,7 +603,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_ShadowRow_TryDeleteMember_System_Dynamic_DeleteMemberBinder_.md&amp;value=---%0Auid%3A%20Linq2Shadow.ShadowRow.TryDeleteMember(System.Dynamic.DeleteMemberBinder)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/ShadowRow.cs/#L53">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/ShadowRow.cs/#L53">View Source</a>
   </span>
   <a id="Linq2Shadow_ShadowRow_TryDeleteMember_" data-uid="Linq2Shadow.ShadowRow.TryDeleteMember*"></a>
   <h4 id="Linq2Shadow_ShadowRow_TryDeleteMember_System_Dynamic_DeleteMemberBinder_" data-uid="Linq2Shadow.ShadowRow.TryDeleteMember(System.Dynamic.DeleteMemberBinder)">TryDeleteMember(DeleteMemberBinder)</h4>
@@ -652,7 +652,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_ShadowRow_TryGetIndex_System_Dynamic_GetIndexBinder_System_Object___System_Object__.md&amp;value=---%0Auid%3A%20Linq2Shadow.ShadowRow.TryGetIndex(System.Dynamic.GetIndexBinder%2CSystem.Object%5B%5D%2CSystem.Object%40)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/ShadowRow.cs/#L58">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/ShadowRow.cs/#L58">View Source</a>
   </span>
   <a id="Linq2Shadow_ShadowRow_TryGetIndex_" data-uid="Linq2Shadow.ShadowRow.TryGetIndex*"></a>
   <h4 id="Linq2Shadow_ShadowRow_TryGetIndex_System_Dynamic_GetIndexBinder_System_Object___System_Object__" data-uid="Linq2Shadow.ShadowRow.TryGetIndex(System.Dynamic.GetIndexBinder,System.Object[],System.Object@)">TryGetIndex(GetIndexBinder, Object[], out Object)</h4>
@@ -711,7 +711,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_ShadowRow_TryGetMember_System_Dynamic_GetMemberBinder_System_Object__.md&amp;value=---%0Auid%3A%20Linq2Shadow.ShadowRow.TryGetMember(System.Dynamic.GetMemberBinder%2CSystem.Object%40)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/ShadowRow.cs/#L72">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/ShadowRow.cs/#L72">View Source</a>
   </span>
   <a id="Linq2Shadow_ShadowRow_TryGetMember_" data-uid="Linq2Shadow.ShadowRow.TryGetMember*"></a>
   <h4 id="Linq2Shadow_ShadowRow_TryGetMember_System_Dynamic_GetMemberBinder_System_Object__" data-uid="Linq2Shadow.ShadowRow.TryGetMember(System.Dynamic.GetMemberBinder,System.Object@)">TryGetMember(GetMemberBinder, out Object)</h4>
@@ -765,7 +765,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_ShadowRow_TryGetValue_System_String_System_Object__.md&amp;value=---%0Auid%3A%20Linq2Shadow.ShadowRow.TryGetValue(System.String%2CSystem.Object%40)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/ShadowRow.cs/#L116">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/ShadowRow.cs/#L116">View Source</a>
   </span>
   <a id="Linq2Shadow_ShadowRow_TryGetValue_" data-uid="Linq2Shadow.ShadowRow.TryGetValue*"></a>
   <h4 id="Linq2Shadow_ShadowRow_TryGetValue_System_String_System_Object__" data-uid="Linq2Shadow.ShadowRow.TryGetValue(System.String,System.Object@)">TryGetValue(String, out Object)</h4>
@@ -817,7 +817,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_ShadowRow_TryInvoke_System_Dynamic_InvokeBinder_System_Object___System_Object__.md&amp;value=---%0Auid%3A%20Linq2Shadow.ShadowRow.TryInvoke(System.Dynamic.InvokeBinder%2CSystem.Object%5B%5D%2CSystem.Object%40)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/ShadowRow.cs/#L79">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/ShadowRow.cs/#L79">View Source</a>
   </span>
   <a id="Linq2Shadow_ShadowRow_TryInvoke_" data-uid="Linq2Shadow.ShadowRow.TryInvoke*"></a>
   <h4 id="Linq2Shadow_ShadowRow_TryInvoke_System_Dynamic_InvokeBinder_System_Object___System_Object__" data-uid="Linq2Shadow.ShadowRow.TryInvoke(System.Dynamic.InvokeBinder,System.Object[],System.Object@)">TryInvoke(InvokeBinder, Object[], out Object)</h4>
@@ -876,7 +876,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_ShadowRow_TryInvokeMember_System_Dynamic_InvokeMemberBinder_System_Object___System_Object__.md&amp;value=---%0Auid%3A%20Linq2Shadow.ShadowRow.TryInvokeMember(System.Dynamic.InvokeMemberBinder%2CSystem.Object%5B%5D%2CSystem.Object%40)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/ShadowRow.cs/#L85">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/ShadowRow.cs/#L85">View Source</a>
   </span>
   <a id="Linq2Shadow_ShadowRow_TryInvokeMember_" data-uid="Linq2Shadow.ShadowRow.TryInvokeMember*"></a>
   <h4 id="Linq2Shadow_ShadowRow_TryInvokeMember_System_Dynamic_InvokeMemberBinder_System_Object___System_Object__" data-uid="Linq2Shadow.ShadowRow.TryInvokeMember(System.Dynamic.InvokeMemberBinder,System.Object[],System.Object@)">TryInvokeMember(InvokeMemberBinder, Object[], out Object)</h4>
@@ -935,7 +935,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_ShadowRow_TrySetIndex_System_Dynamic_SetIndexBinder_System_Object___System_Object_.md&amp;value=---%0Auid%3A%20Linq2Shadow.ShadowRow.TrySetIndex(System.Dynamic.SetIndexBinder%2CSystem.Object%5B%5D%2CSystem.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/ShadowRow.cs/#L91">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/ShadowRow.cs/#L91">View Source</a>
   </span>
   <a id="Linq2Shadow_ShadowRow_TrySetIndex_" data-uid="Linq2Shadow.ShadowRow.TrySetIndex*"></a>
   <h4 id="Linq2Shadow_ShadowRow_TrySetIndex_System_Dynamic_SetIndexBinder_System_Object___System_Object_" data-uid="Linq2Shadow.ShadowRow.TrySetIndex(System.Dynamic.SetIndexBinder,System.Object[],System.Object)">TrySetIndex(SetIndexBinder, Object[], Object)</h4>
@@ -994,7 +994,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_ShadowRow_TrySetMember_System_Dynamic_SetMemberBinder_System_Object_.md&amp;value=---%0Auid%3A%20Linq2Shadow.ShadowRow.TrySetMember(System.Dynamic.SetMemberBinder%2CSystem.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/ShadowRow.cs/#L96">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/ShadowRow.cs/#L96">View Source</a>
   </span>
   <a id="Linq2Shadow_ShadowRow_TrySetMember_" data-uid="Linq2Shadow.ShadowRow.TrySetMember*"></a>
   <h4 id="Linq2Shadow_ShadowRow_TrySetMember_System_Dynamic_SetMemberBinder_System_Object_" data-uid="Linq2Shadow.ShadowRow.TrySetMember(System.Dynamic.SetMemberBinder,System.Object)">TrySetMember(SetMemberBinder, Object)</h4>
@@ -1048,7 +1048,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_ShadowRow_TryUnaryOperation_System_Dynamic_UnaryOperationBinder_System_Object__.md&amp;value=---%0Auid%3A%20Linq2Shadow.ShadowRow.TryUnaryOperation(System.Dynamic.UnaryOperationBinder%2CSystem.Object%40)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/ShadowRow.cs/#L101">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/ShadowRow.cs/#L101">View Source</a>
   </span>
   <a id="Linq2Shadow_ShadowRow_TryUnaryOperation_" data-uid="Linq2Shadow.ShadowRow.TryUnaryOperation*"></a>
   <h4 id="Linq2Shadow_ShadowRow_TryUnaryOperation_System_Dynamic_UnaryOperationBinder_System_Object__" data-uid="Linq2Shadow.ShadowRow.TryUnaryOperation(System.Dynamic.UnaryOperationBinder,System.Object@)">TryUnaryOperation(UnaryOperationBinder, out Object)</h4>
@@ -1104,7 +1104,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_ShadowRow_op_Implicit_Linq2Shadow_ShadowRow__System_Collections_Generic_Dictionary_System_String_System_Object_.md&amp;value=---%0Auid%3A%20Linq2Shadow.ShadowRow.op_Implicit(Linq2Shadow.ShadowRow)~System.Collections.Generic.Dictionary%7BSystem.String%2CSystem.Object%7D%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/ShadowRow.cs/#L14">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/ShadowRow.cs/#L14">View Source</a>
   </span>
   <a id="Linq2Shadow_ShadowRow_op_Implicit_" data-uid="Linq2Shadow.ShadowRow.op_Implicit*"></a>
   <h4 id="Linq2Shadow_ShadowRow_op_Implicit_Linq2Shadow_ShadowRow__System_Collections_Generic_Dictionary_System_String_System_Object_" data-uid="Linq2Shadow.ShadowRow.op_Implicit(Linq2Shadow.ShadowRow)~System.Collections.Generic.Dictionary{System.String,System.Object}">Implicit(ShadowRow to Dictionary&lt;String, Object&gt;)</h4>
@@ -1153,7 +1153,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_ShadowRow_System_Collections_IEnumerable_GetEnumerator.md&amp;value=---%0Auid%3A%20Linq2Shadow.ShadowRow.System%23Collections%23IEnumerable%23GetEnumerator%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/ShadowRow.cs/#L110">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/ShadowRow.cs/#L110">View Source</a>
   </span>
   <a id="Linq2Shadow_ShadowRow_System_Collections_IEnumerable_GetEnumerator_" data-uid="Linq2Shadow.ShadowRow.System#Collections#IEnumerable#GetEnumerator*"></a>
   <h4 id="Linq2Shadow_ShadowRow_System_Collections_IEnumerable_GetEnumerator" data-uid="Linq2Shadow.ShadowRow.System#Collections#IEnumerable#GetEnumerator">IEnumerable.GetEnumerator()</h4>
@@ -1205,7 +1205,7 @@
                     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_ShadowRow.md&amp;value=---%0Auid%3A%20Linq2Shadow.ShadowRow%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/ShadowRow.cs/#L11" class="contribution-link">View Source</a>
+                    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/ShadowRow.cs/#L11" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/Linq2Shadow.Utils.ExpressionBuilders.Predicates.html
+++ b/docs/api/Linq2Shadow.Utils.ExpressionBuilders.Predicates.html
@@ -115,10 +115,153 @@
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
+    <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_And_System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean___System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean___.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.And(System.Linq.Expressions.Expression%7BSystem.Func%7BLinq2Shadow.ShadowRow%2CSystem.Boolean%7D%7D%2CSystem.Linq.Expressions.Expression%7BSystem.Func%7BLinq2Shadow.ShadowRow%2CSystem.Boolean%7D%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1531">View Source</a>
+  </span>
+  <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_And_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.And*"></a>
+  <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_And_System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean___System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean___" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.And(System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}},System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}})">And(Expression&lt;Func&lt;ShadowRow, Boolean&gt;&gt;, Expression&lt;Func&lt;ShadowRow, Boolean&gt;&gt;)</h4>
+  <div class="markdown level1 summary"><p>Build the logical expression based on the AND operator.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static Expression&lt;Func&lt;ShadowRow, bool&gt;&gt; And(Expression&lt;Func&lt;ShadowRow, bool&gt;&gt; left, Expression&lt;Func&lt;ShadowRow, bool&gt;&gt; right)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">System.Linq.Expressions.Expression</span>&lt;<span class="xref">System.Func</span>&lt;<a class="xref" href="Linq2Shadow.ShadowRow.html">ShadowRow</a>, <span class="xref">System.Boolean</span>&gt;&gt;</td>
+        <td><span class="parametername">left</span></td>
+        <td><p>Left operand.</p>
+</td>
+      </tr>
+      <tr>
+        <td><span class="xref">System.Linq.Expressions.Expression</span>&lt;<span class="xref">System.Func</span>&lt;<a class="xref" href="Linq2Shadow.ShadowRow.html">ShadowRow</a>, <span class="xref">System.Boolean</span>&gt;&gt;</td>
+        <td><span class="parametername">right</span></td>
+        <td><p>Right operand.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">System.Linq.Expressions.Expression</span>&lt;<span class="xref">System.Func</span>&lt;<a class="xref" href="Linq2Shadow.ShadowRow.html">ShadowRow</a>, <span class="xref">System.Boolean</span>&gt;&gt;</td>
+        <td><p>Builded predicate.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="exceptions">Exceptions</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Condition</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">System.ArgumentNullException</span></td>
+        <td><p>Will throw when any operand is null.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_And_System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean_____.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.And(System.Linq.Expressions.Expression%7BSystem.Func%7BLinq2Shadow.ShadowRow%2CSystem.Boolean%7D%7D%5B%5D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1508">View Source</a>
+  </span>
+  <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_And_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.And*"></a>
+  <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_And_System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean_____" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.And(System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}}[])">And(Expression&lt;Func&lt;ShadowRow, Boolean&gt;&gt;[])</h4>
+  <div class="markdown level1 summary"><p>Build the logical expression based on the AND operator.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static Expression&lt;Func&lt;ShadowRow, bool&gt;&gt; And(Expression&lt;Func&lt;ShadowRow, bool&gt;&gt;[] predicates)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">System.Linq.Expressions.Expression</span>&lt;<span class="xref">System.Func</span>&lt;<a class="xref" href="Linq2Shadow.ShadowRow.html">ShadowRow</a>, <span class="xref">System.Boolean</span>&gt;&gt;[]</td>
+        <td><span class="parametername">predicates</span></td>
+        <td><p>The operands.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">System.Linq.Expressions.Expression</span>&lt;<span class="xref">System.Func</span>&lt;<a class="xref" href="Linq2Shadow.ShadowRow.html">ShadowRow</a>, <span class="xref">System.Boolean</span>&gt;&gt;</td>
+        <td><p>Builded predicate.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="exceptions">Exceptions</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Condition</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">System.ArgumentNullException</span></td>
+        <td><p>Will throw when <code data-dev-comment-type="paramref" class="paramref">predicates</code> is null.</p>
+</td>
+      </tr>
+      <tr>
+        <td><span class="xref">System.ArgumentException</span></td>
+        <td><p>Will throw when any operand of <code data-dev-comment-type="paramref" class="paramref">predicates</code> is null.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_System_String_System_Boolean_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals(System.String%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L316">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L316">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_System_String_System_Boolean_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals(System.String,System.Boolean)">AreEquals(String, Boolean)</h4>
@@ -195,7 +338,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_System_String_System_Byte_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals(System.String%2CSystem.Byte)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L302">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L302">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_System_String_System_Byte_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals(System.String,System.Byte)">AreEquals(String, Byte)</h4>
@@ -272,7 +415,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_System_String_System_DateTime_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals(System.String%2CSystem.DateTime)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L358">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L358">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_System_String_System_DateTime_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals(System.String,System.DateTime)">AreEquals(String, DateTime)</h4>
@@ -349,7 +492,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_System_String_System_Decimal_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals(System.String%2CSystem.Decimal)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L288">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L288">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_System_String_System_Decimal_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals(System.String,System.Decimal)">AreEquals(String, Decimal)</h4>
@@ -426,7 +569,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_System_String_System_Double_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals(System.String%2CSystem.Double)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L274">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L274">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_System_String_System_Double_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals(System.String,System.Double)">AreEquals(String, Double)</h4>
@@ -503,7 +646,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_System_String_System_Guid_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals(System.String%2CSystem.Guid)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L260">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L260">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_System_String_System_Guid_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals(System.String,System.Guid)">AreEquals(String, Guid)</h4>
@@ -580,7 +723,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_System_String_System_Int16_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals(System.String%2CSystem.Int16)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L246">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L246">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_System_String_System_Int16_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals(System.String,System.Int16)">AreEquals(String, Int16)</h4>
@@ -657,7 +800,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_System_String_System_Int32_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals(System.String%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L344">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L344">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_System_String_System_Int32_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals(System.String,System.Int32)">AreEquals(String, Int32)</h4>
@@ -734,7 +877,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_System_String_System_Int64_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals(System.String%2CSystem.Int64)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L232">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L232">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_System_String_System_Int64_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals(System.String,System.Int64)">AreEquals(String, Int64)</h4>
@@ -811,7 +954,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_System_String_System_Nullable_System_Boolean__.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals(System.String%2CSystem.Nullable%7BSystem.Boolean%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L80">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L80">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_System_String_System_Nullable_System_Boolean__" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals(System.String,System.Nullable{System.Boolean})">AreEquals(String, Nullable&lt;Boolean&gt;)</h4>
@@ -888,7 +1031,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_System_String_System_Nullable_System_Byte__.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals(System.String%2CSystem.Nullable%7BSystem.Byte%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L96">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L96">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_System_String_System_Nullable_System_Byte__" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals(System.String,System.Nullable{System.Byte})">AreEquals(String, Nullable&lt;Byte&gt;)</h4>
@@ -965,7 +1108,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_System_String_System_Nullable_System_DateTime__.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals(System.String%2CSystem.Nullable%7BSystem.DateTime%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L113">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L113">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_System_String_System_Nullable_System_DateTime__" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals(System.String,System.Nullable{System.DateTime})">AreEquals(String, Nullable&lt;DateTime&gt;)</h4>
@@ -1042,7 +1185,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_System_String_System_Nullable_System_Decimal__.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals(System.String%2CSystem.Nullable%7BSystem.Decimal%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L130">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L130">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_System_String_System_Nullable_System_Decimal__" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals(System.String,System.Nullable{System.Decimal})">AreEquals(String, Nullable&lt;Decimal&gt;)</h4>
@@ -1119,7 +1262,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_System_String_System_Nullable_System_Double__.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals(System.String%2CSystem.Nullable%7BSystem.Double%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L147">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L147">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_System_String_System_Nullable_System_Double__" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals(System.String,System.Nullable{System.Double})">AreEquals(String, Nullable&lt;Double&gt;)</h4>
@@ -1196,7 +1339,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_System_String_System_Nullable_System_Guid__.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals(System.String%2CSystem.Nullable%7BSystem.Guid%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L164">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L164">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_System_String_System_Nullable_System_Guid__" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals(System.String,System.Nullable{System.Guid})">AreEquals(String, Nullable&lt;Guid&gt;)</h4>
@@ -1273,7 +1416,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_System_String_System_Nullable_System_Int16__.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals(System.String%2CSystem.Nullable%7BSystem.Int16%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L181">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L181">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_System_String_System_Nullable_System_Int16__" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals(System.String,System.Nullable{System.Int16})">AreEquals(String, Nullable&lt;Int16&gt;)</h4>
@@ -1350,7 +1493,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_System_String_System_Nullable_System_Int32__.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals(System.String%2CSystem.Nullable%7BSystem.Int32%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L198">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L198">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_System_String_System_Nullable_System_Int32__" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals(System.String,System.Nullable{System.Int32})">AreEquals(String, Nullable&lt;Int32&gt;)</h4>
@@ -1427,7 +1570,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_System_String_System_Nullable_System_Int64__.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals(System.String%2CSystem.Nullable%7BSystem.Int64%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L215">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L215">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_System_String_System_Nullable_System_Int64__" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals(System.String,System.Nullable{System.Int64})">AreEquals(String, Nullable&lt;Int64&gt;)</h4>
@@ -1504,7 +1647,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_System_String_System_String_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals(System.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L330">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L330">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_System_String_System_String_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals(System.String,System.String)">AreEquals(String, String)</h4>
@@ -1581,7 +1724,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_System_String_System_Boolean_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals(System.String%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L629">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L629">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_System_String_System_Boolean_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals(System.String,System.Boolean)">AreNotEquals(String, Boolean)</h4>
@@ -1658,7 +1801,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_System_String_System_Byte_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals(System.String%2CSystem.Byte)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L615">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L615">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_System_String_System_Byte_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals(System.String,System.Byte)">AreNotEquals(String, Byte)</h4>
@@ -1735,7 +1878,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_System_String_System_DateTime_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals(System.String%2CSystem.DateTime)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L671">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L671">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_System_String_System_DateTime_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals(System.String,System.DateTime)">AreNotEquals(String, DateTime)</h4>
@@ -1812,7 +1955,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_System_String_System_Decimal_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals(System.String%2CSystem.Decimal)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L601">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L601">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_System_String_System_Decimal_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals(System.String,System.Decimal)">AreNotEquals(String, Decimal)</h4>
@@ -1889,7 +2032,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_System_String_System_Double_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals(System.String%2CSystem.Double)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L587">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L587">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_System_String_System_Double_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals(System.String,System.Double)">AreNotEquals(String, Double)</h4>
@@ -1966,7 +2109,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_System_String_System_Guid_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals(System.String%2CSystem.Guid)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L573">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L573">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_System_String_System_Guid_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals(System.String,System.Guid)">AreNotEquals(String, Guid)</h4>
@@ -2043,7 +2186,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_System_String_System_Int16_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals(System.String%2CSystem.Int16)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L559">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L559">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_System_String_System_Int16_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals(System.String,System.Int16)">AreNotEquals(String, Int16)</h4>
@@ -2120,7 +2263,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_System_String_System_Int32_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals(System.String%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L643">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L643">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_System_String_System_Int32_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals(System.String,System.Int32)">AreNotEquals(String, Int32)</h4>
@@ -2197,7 +2340,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_System_String_System_Int64_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals(System.String%2CSystem.Int64)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L545">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L545">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_System_String_System_Int64_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals(System.String,System.Int64)">AreNotEquals(String, Int64)</h4>
@@ -2274,7 +2417,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_System_String_System_Nullable_System_Boolean__.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals(System.String%2CSystem.Nullable%7BSystem.Boolean%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L401">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L401">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_System_String_System_Nullable_System_Boolean__" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals(System.String,System.Nullable{System.Boolean})">AreNotEquals(String, Nullable&lt;Boolean&gt;)</h4>
@@ -2351,7 +2494,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_System_String_System_Nullable_System_Byte__.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals(System.String%2CSystem.Nullable%7BSystem.Byte%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L417">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L417">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_System_String_System_Nullable_System_Byte__" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals(System.String,System.Nullable{System.Byte})">AreNotEquals(String, Nullable&lt;Byte&gt;)</h4>
@@ -2428,7 +2571,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_System_String_System_Nullable_System_DateTime__.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals(System.String%2CSystem.Nullable%7BSystem.DateTime%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L433">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L433">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_System_String_System_Nullable_System_DateTime__" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals(System.String,System.Nullable{System.DateTime})">AreNotEquals(String, Nullable&lt;DateTime&gt;)</h4>
@@ -2505,7 +2648,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_System_String_System_Nullable_System_Decimal__.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals(System.String%2CSystem.Nullable%7BSystem.Decimal%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L449">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L449">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_System_String_System_Nullable_System_Decimal__" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals(System.String,System.Nullable{System.Decimal})">AreNotEquals(String, Nullable&lt;Decimal&gt;)</h4>
@@ -2582,7 +2725,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_System_String_System_Nullable_System_Double__.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals(System.String%2CSystem.Nullable%7BSystem.Double%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L465">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L465">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_System_String_System_Nullable_System_Double__" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals(System.String,System.Nullable{System.Double})">AreNotEquals(String, Nullable&lt;Double&gt;)</h4>
@@ -2659,7 +2802,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_System_String_System_Nullable_System_Guid__.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals(System.String%2CSystem.Nullable%7BSystem.Guid%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L481">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L481">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_System_String_System_Nullable_System_Guid__" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals(System.String,System.Nullable{System.Guid})">AreNotEquals(String, Nullable&lt;Guid&gt;)</h4>
@@ -2736,7 +2879,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_System_String_System_Nullable_System_Int16__.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals(System.String%2CSystem.Nullable%7BSystem.Int16%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L497">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L497">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_System_String_System_Nullable_System_Int16__" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals(System.String,System.Nullable{System.Int16})">AreNotEquals(String, Nullable&lt;Int16&gt;)</h4>
@@ -2813,7 +2956,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_System_String_System_Nullable_System_Int32__.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals(System.String%2CSystem.Nullable%7BSystem.Int32%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L513">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L513">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_System_String_System_Nullable_System_Int32__" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals(System.String,System.Nullable{System.Int32})">AreNotEquals(String, Nullable&lt;Int32&gt;)</h4>
@@ -2890,7 +3033,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_System_String_System_Nullable_System_Int64__.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals(System.String%2CSystem.Nullable%7BSystem.Int64%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L529">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L529">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_System_String_System_Nullable_System_Int64__" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals(System.String,System.Nullable{System.Int64})">AreNotEquals(String, Nullable&lt;Int64&gt;)</h4>
@@ -2967,7 +3110,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_System_String_System_String_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals(System.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L657">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L657">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreNotEquals_System_String_System_String_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreNotEquals(System.String,System.String)">AreNotEquals(String, String)</h4>
@@ -3044,7 +3187,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_CollectionContains__1_System_Collections_Generic_IEnumerable___0__System_String_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.CollectionContains%60%601(System.Collections.Generic.IEnumerable%7B%60%600%7D%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L31">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L31">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_CollectionContains_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.CollectionContains*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_CollectionContains__1_System_Collections_Generic_IEnumerable___0__System_String_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.CollectionContains``1(System.Collections.Generic.IEnumerable{``0},System.String)">CollectionContains&lt;T&gt;(IEnumerable&lt;T&gt;, String)</h4>
@@ -3137,7 +3280,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_CollectionNotContains__1_System_Collections_Generic_IEnumerable___0__System_String_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.CollectionNotContains%60%601(System.Collections.Generic.IEnumerable%7B%60%600%7D%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L54">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L54">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_CollectionNotContains_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.CollectionNotContains*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_CollectionNotContains__1_System_Collections_Generic_IEnumerable___0__System_String_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.CollectionNotContains``1(System.Collections.Generic.IEnumerable{``0},System.String)">CollectionNotContains&lt;T&gt;(IEnumerable&lt;T&gt;, String)</h4>
@@ -3230,7 +3373,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThan_System_String_System_Byte_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThan(System.String%2CSystem.Byte)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L867">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L867">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThan_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThan*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThan_System_String_System_Byte_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThan(System.String,System.Byte)">GreaterThan(String, Byte)</h4>
@@ -3307,7 +3450,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThan_System_String_System_DateTime_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThan(System.String%2CSystem.DateTime)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L893">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L893">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThan_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThan*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThan_System_String_System_DateTime_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThan(System.String,System.DateTime)">GreaterThan(String, DateTime)</h4>
@@ -3384,7 +3527,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThan_System_String_System_Decimal_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThan(System.String%2CSystem.Decimal)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L854">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L854">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThan_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThan*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThan_System_String_System_Decimal_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThan(System.String,System.Decimal)">GreaterThan(String, Decimal)</h4>
@@ -3461,7 +3604,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThan_System_String_System_Double_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThan(System.String%2CSystem.Double)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L841">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L841">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThan_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThan*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThan_System_String_System_Double_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThan(System.String,System.Double)">GreaterThan(String, Double)</h4>
@@ -3538,7 +3681,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThan_System_String_System_Int16_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThan(System.String%2CSystem.Int16)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L828">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L828">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThan_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThan*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThan_System_String_System_Int16_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThan(System.String,System.Int16)">GreaterThan(String, Int16)</h4>
@@ -3615,7 +3758,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThan_System_String_System_Int32_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThan(System.String%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L880">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L880">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThan_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThan*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThan_System_String_System_Int32_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThan(System.String,System.Int32)">GreaterThan(String, Int32)</h4>
@@ -3692,7 +3835,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThan_System_String_System_Int64_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThan(System.String%2CSystem.Int64)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L815">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L815">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThan_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThan*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThan_System_String_System_Int64_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThan(System.String,System.Int64)">GreaterThan(String, Int64)</h4>
@@ -3769,7 +3912,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_System_String_System_Byte_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual(System.String%2CSystem.Byte)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1093">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1093">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_System_String_System_Byte_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual(System.String,System.Byte)">GreaterThanOrEqual(String, Byte)</h4>
@@ -3846,7 +3989,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_System_String_System_DateTime_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual(System.String%2CSystem.DateTime)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1119">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1119">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_System_String_System_DateTime_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual(System.String,System.DateTime)">GreaterThanOrEqual(String, DateTime)</h4>
@@ -3923,7 +4066,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_System_String_System_Decimal_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual(System.String%2CSystem.Decimal)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1080">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1080">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_System_String_System_Decimal_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual(System.String,System.Decimal)">GreaterThanOrEqual(String, Decimal)</h4>
@@ -4000,7 +4143,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_System_String_System_Double_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual(System.String%2CSystem.Double)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1067">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1067">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_System_String_System_Double_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual(System.String,System.Double)">GreaterThanOrEqual(String, Double)</h4>
@@ -4077,7 +4220,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_System_String_System_Int16_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual(System.String%2CSystem.Int16)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1054">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1054">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_System_String_System_Int16_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual(System.String,System.Int16)">GreaterThanOrEqual(String, Int16)</h4>
@@ -4154,7 +4297,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_System_String_System_Int32_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual(System.String%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1106">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1106">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_System_String_System_Int32_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual(System.String,System.Int32)">GreaterThanOrEqual(String, Int32)</h4>
@@ -4231,7 +4374,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_System_String_System_Int64_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual(System.String%2CSystem.Int64)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1041">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1041">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_System_String_System_Int64_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual(System.String,System.Int64)">GreaterThanOrEqual(String, Int64)</h4>
@@ -4308,7 +4451,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_System_String_System_Nullable_System_Byte__.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual(System.String%2CSystem.Nullable%7BSystem.Byte%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L936">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L936">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_System_String_System_Nullable_System_Byte__" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual(System.String,System.Nullable{System.Byte})">GreaterThanOrEqual(String, Nullable&lt;Byte&gt;)</h4>
@@ -4385,7 +4528,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_System_String_System_Nullable_System_DateTime__.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual(System.String%2CSystem.Nullable%7BSystem.DateTime%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L951">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L951">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_System_String_System_Nullable_System_DateTime__" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual(System.String,System.Nullable{System.DateTime})">GreaterThanOrEqual(String, Nullable&lt;DateTime&gt;)</h4>
@@ -4462,7 +4605,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_System_String_System_Nullable_System_Decimal__.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual(System.String%2CSystem.Nullable%7BSystem.Decimal%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L966">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L966">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_System_String_System_Nullable_System_Decimal__" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual(System.String,System.Nullable{System.Decimal})">GreaterThanOrEqual(String, Nullable&lt;Decimal&gt;)</h4>
@@ -4539,7 +4682,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_System_String_System_Nullable_System_Double__.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual(System.String%2CSystem.Nullable%7BSystem.Double%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L981">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L981">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_System_String_System_Nullable_System_Double__" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual(System.String,System.Nullable{System.Double})">GreaterThanOrEqual(String, Nullable&lt;Double&gt;)</h4>
@@ -4616,7 +4759,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_System_String_System_Nullable_System_Int16__.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual(System.String%2CSystem.Nullable%7BSystem.Int16%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L996">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L996">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_System_String_System_Nullable_System_Int16__" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual(System.String,System.Nullable{System.Int16})">GreaterThanOrEqual(String, Nullable&lt;Int16&gt;)</h4>
@@ -4693,7 +4836,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_System_String_System_Nullable_System_Int32__.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual(System.String%2CSystem.Nullable%7BSystem.Int32%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1011">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1011">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_System_String_System_Nullable_System_Int32__" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual(System.String,System.Nullable{System.Int32})">GreaterThanOrEqual(String, Nullable&lt;Int32&gt;)</h4>
@@ -4770,7 +4913,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_System_String_System_Nullable_System_Int64__.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual(System.String%2CSystem.Nullable%7BSystem.Int64%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1026">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1026">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_GreaterThanOrEqual_System_String_System_Nullable_System_Int64__" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.GreaterThanOrEqual(System.String,System.Nullable{System.Int64})">GreaterThanOrEqual(String, Nullable&lt;Int64&gt;)</h4>
@@ -4847,7 +4990,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThan_System_String_System_Byte_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThan(System.String%2CSystem.Byte)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1214">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1214">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThan_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThan*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThan_System_String_System_Byte_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThan(System.String,System.Byte)">LessThan(String, Byte)</h4>
@@ -4924,7 +5067,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThan_System_String_System_DateTime_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThan(System.String%2CSystem.DateTime)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1240">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1240">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThan_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThan*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThan_System_String_System_DateTime_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThan(System.String,System.DateTime)">LessThan(String, DateTime)</h4>
@@ -5001,7 +5144,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThan_System_String_System_Decimal_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThan(System.String%2CSystem.Decimal)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1201">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1201">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThan_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThan*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThan_System_String_System_Decimal_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThan(System.String,System.Decimal)">LessThan(String, Decimal)</h4>
@@ -5078,7 +5221,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThan_System_String_System_Double_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThan(System.String%2CSystem.Double)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1188">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1188">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThan_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThan*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThan_System_String_System_Double_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThan(System.String,System.Double)">LessThan(String, Double)</h4>
@@ -5155,7 +5298,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThan_System_String_System_Int16_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThan(System.String%2CSystem.Int16)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1175">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1175">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThan_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThan*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThan_System_String_System_Int16_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThan(System.String,System.Int16)">LessThan(String, Int16)</h4>
@@ -5232,7 +5375,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThan_System_String_System_Int32_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThan(System.String%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1227">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1227">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThan_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThan*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThan_System_String_System_Int32_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThan(System.String,System.Int32)">LessThan(String, Int32)</h4>
@@ -5309,7 +5452,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThan_System_String_System_Int64_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThan(System.String%2CSystem.Int64)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1162">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1162">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThan_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThan*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThan_System_String_System_Int64_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThan(System.String,System.Int64)">LessThan(String, Int64)</h4>
@@ -5386,7 +5529,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_System_String_System_Byte_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual(System.String%2CSystem.Byte)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1440">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1440">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_System_String_System_Byte_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual(System.String,System.Byte)">LessThanOrEqual(String, Byte)</h4>
@@ -5463,7 +5606,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_System_String_System_DateTime_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual(System.String%2CSystem.DateTime)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1466">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1466">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_System_String_System_DateTime_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual(System.String,System.DateTime)">LessThanOrEqual(String, DateTime)</h4>
@@ -5540,7 +5683,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_System_String_System_Decimal_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual(System.String%2CSystem.Decimal)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1427">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1427">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_System_String_System_Decimal_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual(System.String,System.Decimal)">LessThanOrEqual(String, Decimal)</h4>
@@ -5617,7 +5760,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_System_String_System_Double_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual(System.String%2CSystem.Double)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1414">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1414">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_System_String_System_Double_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual(System.String,System.Double)">LessThanOrEqual(String, Double)</h4>
@@ -5694,7 +5837,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_System_String_System_Int16_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual(System.String%2CSystem.Int16)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1401">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1401">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_System_String_System_Int16_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual(System.String,System.Int16)">LessThanOrEqual(String, Int16)</h4>
@@ -5771,7 +5914,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_System_String_System_Int32_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual(System.String%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1453">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1453">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_System_String_System_Int32_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual(System.String,System.Int32)">LessThanOrEqual(String, Int32)</h4>
@@ -5848,7 +5991,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_System_String_System_Int64_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual(System.String%2CSystem.Int64)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1388">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1388">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_System_String_System_Int64_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual(System.String,System.Int64)">LessThanOrEqual(String, Int64)</h4>
@@ -5925,7 +6068,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_System_String_System_Nullable_System_Byte__.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual(System.String%2CSystem.Nullable%7BSystem.Byte%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1283">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1283">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_System_String_System_Nullable_System_Byte__" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual(System.String,System.Nullable{System.Byte})">LessThanOrEqual(String, Nullable&lt;Byte&gt;)</h4>
@@ -6002,7 +6145,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_System_String_System_Nullable_System_DateTime__.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual(System.String%2CSystem.Nullable%7BSystem.DateTime%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1298">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1298">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_System_String_System_Nullable_System_DateTime__" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual(System.String,System.Nullable{System.DateTime})">LessThanOrEqual(String, Nullable&lt;DateTime&gt;)</h4>
@@ -6079,7 +6222,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_System_String_System_Nullable_System_Decimal__.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual(System.String%2CSystem.Nullable%7BSystem.Decimal%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1313">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1313">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_System_String_System_Nullable_System_Decimal__" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual(System.String,System.Nullable{System.Decimal})">LessThanOrEqual(String, Nullable&lt;Decimal&gt;)</h4>
@@ -6156,7 +6299,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_System_String_System_Nullable_System_Double__.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual(System.String%2CSystem.Nullable%7BSystem.Double%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1328">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1328">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_System_String_System_Nullable_System_Double__" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual(System.String,System.Nullable{System.Double})">LessThanOrEqual(String, Nullable&lt;Double&gt;)</h4>
@@ -6233,7 +6376,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_System_String_System_Nullable_System_Int16__.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual(System.String%2CSystem.Nullable%7BSystem.Int16%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1343">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1343">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_System_String_System_Nullable_System_Int16__" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual(System.String,System.Nullable{System.Int16})">LessThanOrEqual(String, Nullable&lt;Int16&gt;)</h4>
@@ -6310,7 +6453,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_System_String_System_Nullable_System_Int32__.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual(System.String%2CSystem.Nullable%7BSystem.Int32%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1358">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1358">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_System_String_System_Nullable_System_Int32__" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual(System.String,System.Nullable{System.Int32})">LessThanOrEqual(String, Nullable&lt;Int32&gt;)</h4>
@@ -6387,7 +6530,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_System_String_System_Nullable_System_Int64__.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual(System.String%2CSystem.Nullable%7BSystem.Int64%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1373">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1373">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LessThanOrEqual_System_String_System_Nullable_System_Int64__" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual(System.String,System.Nullable{System.Int64})">LessThanOrEqual(String, Nullable&lt;Int64&gt;)</h4>
@@ -6461,19 +6604,19 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_LogicalAnd_System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean___System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean___.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.LogicalAnd(System.Linq.Expressions.Expression%7BSystem.Func%7BLinq2Shadow.ShadowRow%2CSystem.Boolean%7D%7D%2CSystem.Linq.Expressions.Expression%7BSystem.Func%7BLinq2Shadow.ShadowRow%2CSystem.Boolean%7D%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_Or_System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean___System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean___.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.Or(System.Linq.Expressions.Expression%7BSystem.Func%7BLinq2Shadow.ShadowRow%2CSystem.Boolean%7D%7D%2CSystem.Linq.Expressions.Expression%7BSystem.Func%7BLinq2Shadow.ShadowRow%2CSystem.Boolean%7D%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1531">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1577">View Source</a>
   </span>
-  <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LogicalAnd_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LogicalAnd*"></a>
-  <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LogicalAnd_System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean___System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean___" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LogicalAnd(System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}},System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}})">LogicalAnd(Expression&lt;Func&lt;ShadowRow, Boolean&gt;&gt;, Expression&lt;Func&lt;ShadowRow, Boolean&gt;&gt;)</h4>
-  <div class="markdown level1 summary"><p>Build the logical expression based on the AND operator.</p>
+  <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_Or_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.Or*"></a>
+  <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_Or_System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean___System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean___" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.Or(System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}},System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}})">Or(Expression&lt;Func&lt;ShadowRow, Boolean&gt;&gt;, Expression&lt;Func&lt;ShadowRow, Boolean&gt;&gt;)</h4>
+  <div class="markdown level1 summary"><p>Build the logical expression based on the OR operator.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Expression&lt;Func&lt;ShadowRow, bool&gt;&gt; LogicalAnd(Expression&lt;Func&lt;ShadowRow, bool&gt;&gt; left, Expression&lt;Func&lt;ShadowRow, bool&gt;&gt; right)</code></pre>
+    <pre><code class="lang-csharp hljs">public static Expression&lt;Func&lt;ShadowRow, bool&gt;&gt; Or(Expression&lt;Func&lt;ShadowRow, bool&gt;&gt; left, Expression&lt;Func&lt;ShadowRow, bool&gt;&gt; right)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -6533,162 +6676,19 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_LogicalAnd_System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean_____.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.LogicalAnd(System.Linq.Expressions.Expression%7BSystem.Func%7BLinq2Shadow.ShadowRow%2CSystem.Boolean%7D%7D%5B%5D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_Or_System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean_____.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.Or(System.Linq.Expressions.Expression%7BSystem.Func%7BLinq2Shadow.ShadowRow%2CSystem.Boolean%7D%7D%5B%5D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1508">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1554">View Source</a>
   </span>
-  <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LogicalAnd_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LogicalAnd*"></a>
-  <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LogicalAnd_System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean_____" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LogicalAnd(System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}}[])">LogicalAnd(Expression&lt;Func&lt;ShadowRow, Boolean&gt;&gt;[])</h4>
-  <div class="markdown level1 summary"><p>Build the logical expression based on the AND operator.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Expression&lt;Func&lt;ShadowRow, bool&gt;&gt; LogicalAnd(Expression&lt;Func&lt;ShadowRow, bool&gt;&gt;[] predicates)</code></pre>
-  </div>
-  <h5 class="parameters">Parameters</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Name</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><span class="xref">System.Linq.Expressions.Expression</span>&lt;<span class="xref">System.Func</span>&lt;<a class="xref" href="Linq2Shadow.ShadowRow.html">ShadowRow</a>, <span class="xref">System.Boolean</span>&gt;&gt;[]</td>
-        <td><span class="parametername">predicates</span></td>
-        <td><p>The operands.</p>
-</td>
-      </tr>
-    </tbody>
-  </table>
-  <h5 class="returns">Returns</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><span class="xref">System.Linq.Expressions.Expression</span>&lt;<span class="xref">System.Func</span>&lt;<a class="xref" href="Linq2Shadow.ShadowRow.html">ShadowRow</a>, <span class="xref">System.Boolean</span>&gt;&gt;</td>
-        <td><p>Builded predicate.</p>
-</td>
-      </tr>
-    </tbody>
-  </table>
-  <h5 class="exceptions">Exceptions</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Condition</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><span class="xref">System.ArgumentNullException</span></td>
-        <td><p>Will throw when <code data-dev-comment-type="paramref" class="paramref">predicates</code> is null.</p>
-</td>
-      </tr>
-      <tr>
-        <td><span class="xref">System.ArgumentException</span></td>
-        <td><p>Will throw when any operand of <code data-dev-comment-type="paramref" class="paramref">predicates</code> is null.</p>
-</td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_LogicalOr_System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean___System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean___.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.LogicalOr(System.Linq.Expressions.Expression%7BSystem.Func%7BLinq2Shadow.ShadowRow%2CSystem.Boolean%7D%7D%2CSystem.Linq.Expressions.Expression%7BSystem.Func%7BLinq2Shadow.ShadowRow%2CSystem.Boolean%7D%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1577">View Source</a>
-  </span>
-  <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LogicalOr_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LogicalOr*"></a>
-  <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LogicalOr_System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean___System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean___" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LogicalOr(System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}},System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}})">LogicalOr(Expression&lt;Func&lt;ShadowRow, Boolean&gt;&gt;, Expression&lt;Func&lt;ShadowRow, Boolean&gt;&gt;)</h4>
+  <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_Or_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.Or*"></a>
+  <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_Or_System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean_____" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.Or(System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}}[])">Or(Expression&lt;Func&lt;ShadowRow, Boolean&gt;&gt;[])</h4>
   <div class="markdown level1 summary"><p>Build the logical expression based on the OR operator.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Expression&lt;Func&lt;ShadowRow, bool&gt;&gt; LogicalOr(Expression&lt;Func&lt;ShadowRow, bool&gt;&gt; left, Expression&lt;Func&lt;ShadowRow, bool&gt;&gt; right)</code></pre>
-  </div>
-  <h5 class="parameters">Parameters</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Name</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><span class="xref">System.Linq.Expressions.Expression</span>&lt;<span class="xref">System.Func</span>&lt;<a class="xref" href="Linq2Shadow.ShadowRow.html">ShadowRow</a>, <span class="xref">System.Boolean</span>&gt;&gt;</td>
-        <td><span class="parametername">left</span></td>
-        <td><p>Left operand.</p>
-</td>
-      </tr>
-      <tr>
-        <td><span class="xref">System.Linq.Expressions.Expression</span>&lt;<span class="xref">System.Func</span>&lt;<a class="xref" href="Linq2Shadow.ShadowRow.html">ShadowRow</a>, <span class="xref">System.Boolean</span>&gt;&gt;</td>
-        <td><span class="parametername">right</span></td>
-        <td><p>Right operand.</p>
-</td>
-      </tr>
-    </tbody>
-  </table>
-  <h5 class="returns">Returns</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><span class="xref">System.Linq.Expressions.Expression</span>&lt;<span class="xref">System.Func</span>&lt;<a class="xref" href="Linq2Shadow.ShadowRow.html">ShadowRow</a>, <span class="xref">System.Boolean</span>&gt;&gt;</td>
-        <td><p>Builded predicate.</p>
-</td>
-      </tr>
-    </tbody>
-  </table>
-  <h5 class="exceptions">Exceptions</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Condition</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><span class="xref">System.ArgumentNullException</span></td>
-        <td><p>Will throw when any operand is null.</p>
-</td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_LogicalOr_System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean_____.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.LogicalOr(System.Linq.Expressions.Expression%7BSystem.Func%7BLinq2Shadow.ShadowRow%2CSystem.Boolean%7D%7D%5B%5D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L1554">View Source</a>
-  </span>
-  <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LogicalOr_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LogicalOr*"></a>
-  <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_LogicalOr_System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean_____" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.LogicalOr(System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}}[])">LogicalOr(Expression&lt;Func&lt;ShadowRow, Boolean&gt;&gt;[])</h4>
-  <div class="markdown level1 summary"><p>Build the logical expression based on the OR operator.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Expression&lt;Func&lt;ShadowRow, bool&gt;&gt; LogicalOr(Expression&lt;Func&lt;ShadowRow, bool&gt;&gt;[] predicates)</code></pre>
+    <pre><code class="lang-csharp hljs">public static Expression&lt;Func&lt;ShadowRow, bool&gt;&gt; Or(Expression&lt;Func&lt;ShadowRow, bool&gt;&gt;[] predicates)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -6750,7 +6750,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_StringContains_System_String_System_String_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.StringContains(System.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L714">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L714">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_StringContains_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.StringContains*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_StringContains_System_String_System_String_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.StringContains(System.String,System.String)">StringContains(String, String)</h4>
@@ -6832,7 +6832,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_StringEndsWith_System_String_System_String_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.StringEndsWith(System.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L780">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L780">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_StringEndsWith_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.StringEndsWith*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_StringEndsWith_System_String_System_String_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.StringEndsWith(System.String,System.String)">StringEndsWith(String, String)</h4>
@@ -6914,7 +6914,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates_StringStartsWith_System_String_System_String_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates.StringStartsWith(System.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L748">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L748">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_StringStartsWith_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.StringStartsWith*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_Predicates_StringStartsWith_System_String_System_String_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.Predicates.StringStartsWith(System.String,System.String)">StringStartsWith(String, String)</h4>
@@ -7002,7 +7002,7 @@
                     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_Predicates.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.Predicates%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L18" class="contribution-link">View Source</a>
+                    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L18" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/Linq2Shadow.Utils.ExpressionBuilders.html
+++ b/docs/api/Linq2Shadow.Utils.ExpressionBuilders.html
@@ -118,7 +118,7 @@
     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders_MemberAccess_System_String_.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders.MemberAccess(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.cs/#L28">View Source</a>
+    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.cs/#L28">View Source</a>
   </span>
   <a id="Linq2Shadow_Utils_ExpressionBuilders_MemberAccess_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.MemberAccess*"></a>
   <h4 id="Linq2Shadow_Utils_ExpressionBuilders_MemberAccess_System_String_" data-uid="Linq2Shadow.Utils.ExpressionBuilders.MemberAccess(System.String)">MemberAccess(String)</h4>
@@ -174,7 +174,7 @@
                     <a href="https://github.com/DDzia/Linq2Shadow/new/master/apiSpec/new?filename=Linq2Shadow_Utils_ExpressionBuilders.md&amp;value=---%0Auid%3A%20Linq2Shadow.Utils.ExpressionBuilders%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/member-helper/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L13" class="contribution-link">View Source</a>
+                    <a href="https://github.com/DDzia/Linq2Shadow/blob/feature/or-rename/Linq2Shadow/Utils/ExpressionBuilders.Predicates.cs/#L13" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/get-started/get-started.html
+++ b/docs/get-started/get-started.html
@@ -88,10 +88,10 @@ cd SampleApp
 <p>The DatabaseContext object present the context over pure connection to make query operations(for example: query to table, view, stored procedure, function and etc.). For more info about DatabaseContext, see <a href="/api/Linq2Shadow.DatabaseContext.html">API</a>.</p>
 <div class="NOTE">
 <h5>Note</h5>
-<p>SqlServer connection string is not defined in here code. We will use  connection string from <a href="attachments.html#connection-string">attachments</a>.</p>
+<p>SqlServer connection string is not defined in here code. We will use connection string from <a href="attachments.html#connection-string">attachments</a>.</p>
 </div>
 <p>Instantiating the DatabaseContext object:</p>
-<pre><code class="lang-csharp">Func&lt;SqlConnection&gt; connectionFactory = () =&gt; new SqlConnection(connectionString);  
+<pre><code class="lang-csharp">Func&lt;SqlConnection&gt; connectionFactory = () =&gt; new SqlConnection(connectionString);
 var db = new DatabaseContext(connectionFactory);
 </code></pre>
 <h2 id="shadowrow">ShadowRow</h2>
@@ -131,7 +131,7 @@ IEnumerable&lt;string&gt; propertyNames = userFound.Keys; // [&quot;UserName&quo
 </ul>
 <section id="tabpanel_CeZOj-G++Q_quey-to-table" role="tabpanel" data-tab="quey-to-table">
 
-<pre><code class="lang-csharp">var usersFound = db.QueryToTable(&quot;tUsers&quot;)  
+<pre><code class="lang-csharp">var usersFound = db.QueryToTable(&quot;tUsers&quot;)
     .ToList();
 </code></pre>
 </section>
@@ -141,28 +141,28 @@ IEnumerable&lt;string&gt; propertyNames = userFound.Keys; // [&quot;UserName&quo
 </section>
 <section id="tabpanel_CeZOj-G++Q_quey-to-stored-procedure" role="tabpanel" data-tab="quey-to-stored-procedure" aria-hidden="true" hidden="hidden">
 
-<pre><code class="lang-csharp">var spArgs = new Dictionary&lt;string, object&gt;(){ {&quot;UserName&quot;, &quot;Dzianis&quot;} };  
-var usersFound = db.QueryToStoredProcedure(&quot;spFindUsers&quot;, spArgs)  
+<pre><code class="lang-csharp">var spArgs = new Dictionary&lt;string, object&gt;(){ {&quot;UserName&quot;, &quot;Dzianis&quot;} };
+var usersFound = db.QueryToStoredProcedure(&quot;spFindUsers&quot;, spArgs)
     .ToList();
 
 // TODO: typed params approach
-var spArgsTyped = new { UserName = &quot;Dzianis&quot; };  
-var usersFoundSame = db.QueryToStoredProcedure(&quot;spFindUsers&quot;, spArgsTyped)  
+var spArgsTyped = new { UserName = &quot;Dzianis&quot; };
+var usersFoundSame = db.QueryToStoredProcedure(&quot;spFindUsers&quot;, spArgsTyped)
     .ToList();
 </code></pre>
 </section>
 <section id="tabpanel_CeZOj-G++Q_quey-to-function" role="tabpanel" data-tab="quey-to-function" aria-hidden="true" hidden="hidden">
 
-<pre><code class="lang-csharp">var functionArguments = new object[] { &quot;Dzianis&quot; };  
-var usersFound = db.QueryToStoredProcedure(&quot;fFindUsers&quot;, functionArguments)  
+<pre><code class="lang-csharp">var functionArguments = new object[] { &quot;Dzianis&quot; };
+var usersFound = db.QueryToStoredProcedure(&quot;fFindUsers&quot;, functionArguments)
     .ToList();
 </code></pre>
 </section>
 </div>
 <h3 id="paging-sample">Paging sample</h3>
-<pre><code class="lang-csharp">var userFound = db.QueryToTable(&quot;tUsers&quot;)  
-    .Skip(1)  
-    .Take(1)  
+<pre><code class="lang-csharp">var userFound = db.QueryToTable(&quot;tUsers&quot;)
+    .Skip(1)
+    .Take(1)
     .ToList();
 </code></pre>
 <h3 id="filtering-example">Filtering example</h3>
@@ -170,8 +170,8 @@ var usersFound = db.QueryToStoredProcedure(&quot;fFindUsers&quot;, functionArgum
 <h5>Note</h5>
 <p>More about ExpressionBuilders.Predicates class see <a href="#predicates">below</a>.</p>
 </div>
-<pre><code class="lang-csharp">var userFound = db.QueryToTable(&quot;tUsers&quot;)  
-    .Where(ExpressionBuilders.Predicates.AreEqual(&quot;UserName&quot;, &quot;Dzianis&quot;))  
+<pre><code class="lang-csharp">var userFound = db.QueryToTable(&quot;tUsers&quot;)
+    .Where(ExpressionBuilders.Predicates.AreEqual(&quot;UserName&quot;, &quot;Dzianis&quot;))
     .ToList();
 </code></pre>
 <h3 id="count-example">Count example</h3>
@@ -181,7 +181,7 @@ var usersFound = db.QueryToStoredProcedure(&quot;fFindUsers&quot;, functionArgum
 </div>
 <pre><code class="lang-csharp">var countAl = db.QueryToTable(&quot;tUsers&quot;).Count();
 
-var countDzianises = db.QueryToTable(&quot;tUsers&quot;)  
+var countDzianises = db.QueryToTable(&quot;tUsers&quot;)
     .Count(ExpressionBuilders.Predicates.AreEqual(&quot;UserName&quot;, &quot;Dzianis&quot;));
 </code></pre>
 <h3 id="ordering-example">Ordering example</h3>
@@ -189,9 +189,9 @@ var countDzianises = db.QueryToTable(&quot;tUsers&quot;)
 <h5>Tip</h5>
 <p>Use <strong>ExpressionBuilders.MemberAccess(string memberName)</strong> helper to create attribute-based expression.</p>
 </div>
-<pre><code class="lang-csharp">var usersOrdered = db.QueryToTable(&quot;tUsers&quot;)  
-    .OrderBy(ExpressionBuilders.MemberAccess(&quot;UserName&quot;))  
-    .ThenByDescending(ExpressionBuilders.MemberAccess(&quot;Marrried&quot;))  
+<pre><code class="lang-csharp">var usersOrdered = db.QueryToTable(&quot;tUsers&quot;)
+    .OrderBy(ExpressionBuilders.MemberAccess(&quot;UserName&quot;))
+    .ThenByDescending(ExpressionBuilders.MemberAccess(&quot;Marrried&quot;))
     .ToList();
 </code></pre>
 <h3 id="first-example">First example</h3>
@@ -199,16 +199,16 @@ var countDzianises = db.QueryToTable(&quot;tUsers&quot;)
     .First(); // or FirstOrDefault()
 </code></pre>
 <h3 id="reading-via-loop">Reading via loop</h3>
-<pre><code class="lang-csharp">// All data are not loaded to memory, here.  
-// Data reads like `from row to row`: EnumeratorObj.Move() initiate DbDataReader.Read()  
-foreach(var row in db.QueryToTable(&quot;tUsers&quot;))  
-{  
+<pre><code class="lang-csharp">// All data are not loaded to memory, here.
+// Data reads like `from row to row`: EnumeratorObj.Move() initiate DbDataReader.Read()
+foreach(var row in db.QueryToTable(&quot;tUsers&quot;))
+{
     Console.WriteLine(row[&quot;UserName&quot;]);
 }
 </code></pre>
 <h3 id="select-example">Select example</h3>
-<pre><code class="lang-csharp">var usersFound = db.QueryToTable(&quot;tUsers&quot;)  
-    .SelectOnly(new [] { &quot;Married&quot; })  
+<pre><code class="lang-csharp">var usersFound = db.QueryToTable(&quot;tUsers&quot;)
+    .SelectOnly(new [] { &quot;Married&quot; })
     .First();
 // Output: [0]
 // !Attention!: UserName is skipped
@@ -249,13 +249,13 @@ ExpressionBuilders.Predicates.LessThan(&quot;Age&quot;, 1);
 ExpressionBuilders.Predicates.LessThanOrEqual(&quot;Age&quot;, 1);
 
 // SQL equivalent:  `Age &gt; 1 AND Age &lt; 2`
-ExpressionBuilders.Predicates.LogicalAnd(
+ExpressionBuilders.Predicates.And(
     ExpressionBuilders.Predicates.GreaterThan(&quot;Age&quot;, 1),
     ExpressionBuilders.Predicates.LessThan(&quot;Age&quot;, 2)
 );
 
 // SQL equivalent:  `Age = 1 OR Age = 2`
-ExpressionBuilders.Predicates.LogicalOr(
+ExpressionBuilders.Predicates.Or(
     ExpressionBuilders.Predicates.AreEquals(&quot;Age&quot;, 1),
     ExpressionBuilders.Predicates.AreEquals(&quot;Age&quot;, 2)
 );
@@ -271,20 +271,20 @@ ExpressionBuilders.Predicates.StringStartsWith(&quot;UserName&quot;, &quot;Dzi&q
 </code></pre>
 <h2 id="update-source">Update source</h2>
 <p>Approaches to update data source:</p>
-<pre><code class="lang-csharp">var updateMap = new Dictionary&lt;string, object&gt;(){{&quot;UserName&quot;, &quot;SuperDzianis&quot;}};  
-var updatePredicate = ExpressionBuiders.Predicates.AreEquals(&quot;UserName&quot;, &quot;Dzianis&quot;);  
+<pre><code class="lang-csharp">var updateMap = new Dictionary&lt;string, object&gt;(){{&quot;UserName&quot;, &quot;SuperDzianis&quot;}};
+var updatePredicate = ExpressionBuiders.Predicates.AreEquals(&quot;UserName&quot;, &quot;Dzianis&quot;);
 
-// update all rows  
-var udpdatedUsersCount = db.Update(&quot;tUsers&quot;, updateMap);  
+// update all rows
+var udpdatedUsersCount = db.Update(&quot;tUsers&quot;, updateMap);
 
 // update with predicate(part of data)
-var udpdatedUsersCount = db.Update(&quot;tUsers&quot;, updateMap, updatePredicate);  
+var udpdatedUsersCount = db.Update(&quot;tUsers&quot;, updateMap, updatePredicate);
 
 // same with typed model
-var udpdatedUsersCount = db.Update(&quot;tUsers&quot;, new { UserName=&quot;Dzianis&quot; }, updatePredicate);  
+var udpdatedUsersCount = db.Update(&quot;tUsers&quot;, new { UserName=&quot;Dzianis&quot; }, updatePredicate);
 
 // update asynchronously
-var udpdatedUsersCount = db.UpdateAsync(&quot;tUsers&quot;, new { UserName=&quot;Dzianis&quot; }, CancellationToken.None);  
+var udpdatedUsersCount = db.UpdateAsync(&quot;tUsers&quot;, new { UserName=&quot;Dzianis&quot; }, CancellationToken.None);
 </code></pre>
 <h2 id="remove-from-source">Remove from source</h2>
 <p>Approaches to remove data from sources like table or view:</p>

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -9,7 +9,7 @@
       "output": {
         ".html": {
           "relative_path": "api/Linq2Shadow.DatabaseContext.html",
-          "hash": "Psps+XoHaFby4MUNXOgumg=="
+          "hash": "oO34Hl/BweXMtF95nP9bBw=="
         }
       },
       "is_incremental": true,
@@ -21,7 +21,7 @@
       "output": {
         ".html": {
           "relative_path": "api/Linq2Shadow.Extensions.QueryableAsyncExtensions.html",
-          "hash": "RmOlbiQDnnDJrK6kpROeLA=="
+          "hash": "Z5cPjs0pm2EKTunw4R4zEw=="
         }
       },
       "is_incremental": true,
@@ -33,7 +33,7 @@
       "output": {
         ".html": {
           "relative_path": "api/Linq2Shadow.Extensions.QueryableExtensions.html",
-          "hash": "EvjqEDKZGW07UwzEcwOwIg=="
+          "hash": "Gp5ZRsTKPgkpnvvrD3ePsA=="
         }
       },
       "is_incremental": true,
@@ -57,7 +57,7 @@
       "output": {
         ".html": {
           "relative_path": "api/Linq2Shadow.ShadowRow.html",
-          "hash": "Rr756a2D4AMchj0NDLCCrg=="
+          "hash": "JJ/WdfJL2zQrc8xnPlwarw=="
         }
       },
       "is_incremental": true,
@@ -69,7 +69,7 @@
       "output": {
         ".html": {
           "relative_path": "api/Linq2Shadow.Utils.ExpressionBuilders.Predicates.html",
-          "hash": "3NDUcAESBNwi+ruZExRFqQ=="
+          "hash": "O3DXrnjBIxgZPCiIaQDYkg=="
         }
       },
       "is_incremental": true,
@@ -81,7 +81,7 @@
       "output": {
         ".html": {
           "relative_path": "api/Linq2Shadow.Utils.ExpressionBuilders.html",
-          "hash": "czdvU9Cpq2sJu6dG76O01w=="
+          "hash": "FpJkqKq/2BjB9SbjvJppKw=="
         }
       },
       "is_incremental": true,
@@ -180,7 +180,7 @@
       "output": {
         ".html": {
           "relative_path": "get-started/get-started.html",
-          "hash": "ujHQNucFxUiGJ7uV/q0Aaw=="
+          "hash": "8pv1ryNlVckFISQiEvyISA=="
         }
       },
       "is_incremental": true,
@@ -351,18 +351,18 @@
           "total_file_count": 0,
           "skipped_file_count": 0
         },
-        "ConceptualDocumentProcessor": {
-          "can_incremental": true,
-          "incrementalPhase": "build",
-          "total_file_count": 11,
-          "skipped_file_count": 11
-        },
         "TocDocumentProcessor": {
           "can_incremental": false,
           "details": "Processor TocDocumentProcessor cannot support incremental build because the processor doesn't implement ISupportIncrementalDocumentProcessor interface.",
           "incrementalPhase": "build",
           "total_file_count": 0,
           "skipped_file_count": 0
+        },
+        "ConceptualDocumentProcessor": {
+          "can_incremental": true,
+          "incrementalPhase": "build",
+          "total_file_count": 11,
+          "skipped_file_count": 11
         },
         "ManagedReferenceDocumentProcessor": {
           "can_incremental": true,

--- a/docs/xrefmap.yml
+++ b/docs/xrefmap.yml
@@ -603,6 +603,31 @@ references:
   commentId: T:Linq2Shadow.Utils.ExpressionBuilders.Predicates
   fullName: Linq2Shadow.Utils.ExpressionBuilders.Predicates
   nameWithType: ExpressionBuilders.Predicates
+- uid: Linq2Shadow.Utils.ExpressionBuilders.Predicates.And(System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}},System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}})
+  name: And(Expression<Func<ShadowRow, Boolean>>, Expression<Func<ShadowRow, Boolean>>)
+  href: api/Linq2Shadow.Utils.ExpressionBuilders.Predicates.html#Linq2Shadow_Utils_ExpressionBuilders_Predicates_And_System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean___System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean___
+  commentId: M:Linq2Shadow.Utils.ExpressionBuilders.Predicates.And(System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}},System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}})
+  name.vb: And(Expression(Of Func(Of ShadowRow, Boolean)), Expression(Of Func(Of ShadowRow, Boolean)))
+  fullName: Linq2Shadow.Utils.ExpressionBuilders.Predicates.And(System.Linq.Expressions.Expression<System.Func<Linq2Shadow.ShadowRow, System.Boolean>>, System.Linq.Expressions.Expression<System.Func<Linq2Shadow.ShadowRow, System.Boolean>>)
+  fullName.vb: Linq2Shadow.Utils.ExpressionBuilders.Predicates.And(System.Linq.Expressions.Expression(Of System.Func(Of Linq2Shadow.ShadowRow, System.Boolean)), System.Linq.Expressions.Expression(Of System.Func(Of Linq2Shadow.ShadowRow, System.Boolean)))
+  nameWithType: ExpressionBuilders.Predicates.And(Expression<Func<ShadowRow, Boolean>>, Expression<Func<ShadowRow, Boolean>>)
+  nameWithType.vb: ExpressionBuilders.Predicates.And(Expression(Of Func(Of ShadowRow, Boolean)), Expression(Of Func(Of ShadowRow, Boolean)))
+- uid: Linq2Shadow.Utils.ExpressionBuilders.Predicates.And(System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}}[])
+  name: And(Expression<Func<ShadowRow, Boolean>>[])
+  href: api/Linq2Shadow.Utils.ExpressionBuilders.Predicates.html#Linq2Shadow_Utils_ExpressionBuilders_Predicates_And_System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean_____
+  commentId: M:Linq2Shadow.Utils.ExpressionBuilders.Predicates.And(System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}}[])
+  name.vb: And(Expression(Of Func(Of ShadowRow, Boolean))())
+  fullName: Linq2Shadow.Utils.ExpressionBuilders.Predicates.And(System.Linq.Expressions.Expression<System.Func<Linq2Shadow.ShadowRow, System.Boolean>>[])
+  fullName.vb: Linq2Shadow.Utils.ExpressionBuilders.Predicates.And(System.Linq.Expressions.Expression(Of System.Func(Of Linq2Shadow.ShadowRow, System.Boolean))())
+  nameWithType: ExpressionBuilders.Predicates.And(Expression<Func<ShadowRow, Boolean>>[])
+  nameWithType.vb: ExpressionBuilders.Predicates.And(Expression(Of Func(Of ShadowRow, Boolean))())
+- uid: Linq2Shadow.Utils.ExpressionBuilders.Predicates.And*
+  name: And
+  href: api/Linq2Shadow.Utils.ExpressionBuilders.Predicates.html#Linq2Shadow_Utils_ExpressionBuilders_Predicates_And_
+  commentId: Overload:Linq2Shadow.Utils.ExpressionBuilders.Predicates.And
+  isSpec: "True"
+  fullName: Linq2Shadow.Utils.ExpressionBuilders.Predicates.And
+  nameWithType: ExpressionBuilders.Predicates.And
 - uid: Linq2Shadow.Utils.ExpressionBuilders.Predicates.AreEquals(System.String,System.Boolean)
   name: AreEquals(String, Boolean)
   href: api/Linq2Shadow.Utils.ExpressionBuilders.Predicates.html#Linq2Shadow_Utils_ExpressionBuilders_Predicates_AreEquals_System_String_System_Boolean_
@@ -1253,56 +1278,31 @@ references:
   isSpec: "True"
   fullName: Linq2Shadow.Utils.ExpressionBuilders.Predicates.LessThanOrEqual
   nameWithType: ExpressionBuilders.Predicates.LessThanOrEqual
-- uid: Linq2Shadow.Utils.ExpressionBuilders.Predicates.LogicalAnd(System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}},System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}})
-  name: LogicalAnd(Expression<Func<ShadowRow, Boolean>>, Expression<Func<ShadowRow, Boolean>>)
-  href: api/Linq2Shadow.Utils.ExpressionBuilders.Predicates.html#Linq2Shadow_Utils_ExpressionBuilders_Predicates_LogicalAnd_System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean___System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean___
-  commentId: M:Linq2Shadow.Utils.ExpressionBuilders.Predicates.LogicalAnd(System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}},System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}})
-  name.vb: LogicalAnd(Expression(Of Func(Of ShadowRow, Boolean)), Expression(Of Func(Of ShadowRow, Boolean)))
-  fullName: Linq2Shadow.Utils.ExpressionBuilders.Predicates.LogicalAnd(System.Linq.Expressions.Expression<System.Func<Linq2Shadow.ShadowRow, System.Boolean>>, System.Linq.Expressions.Expression<System.Func<Linq2Shadow.ShadowRow, System.Boolean>>)
-  fullName.vb: Linq2Shadow.Utils.ExpressionBuilders.Predicates.LogicalAnd(System.Linq.Expressions.Expression(Of System.Func(Of Linq2Shadow.ShadowRow, System.Boolean)), System.Linq.Expressions.Expression(Of System.Func(Of Linq2Shadow.ShadowRow, System.Boolean)))
-  nameWithType: ExpressionBuilders.Predicates.LogicalAnd(Expression<Func<ShadowRow, Boolean>>, Expression<Func<ShadowRow, Boolean>>)
-  nameWithType.vb: ExpressionBuilders.Predicates.LogicalAnd(Expression(Of Func(Of ShadowRow, Boolean)), Expression(Of Func(Of ShadowRow, Boolean)))
-- uid: Linq2Shadow.Utils.ExpressionBuilders.Predicates.LogicalAnd(System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}}[])
-  name: LogicalAnd(Expression<Func<ShadowRow, Boolean>>[])
-  href: api/Linq2Shadow.Utils.ExpressionBuilders.Predicates.html#Linq2Shadow_Utils_ExpressionBuilders_Predicates_LogicalAnd_System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean_____
-  commentId: M:Linq2Shadow.Utils.ExpressionBuilders.Predicates.LogicalAnd(System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}}[])
-  name.vb: LogicalAnd(Expression(Of Func(Of ShadowRow, Boolean))())
-  fullName: Linq2Shadow.Utils.ExpressionBuilders.Predicates.LogicalAnd(System.Linq.Expressions.Expression<System.Func<Linq2Shadow.ShadowRow, System.Boolean>>[])
-  fullName.vb: Linq2Shadow.Utils.ExpressionBuilders.Predicates.LogicalAnd(System.Linq.Expressions.Expression(Of System.Func(Of Linq2Shadow.ShadowRow, System.Boolean))())
-  nameWithType: ExpressionBuilders.Predicates.LogicalAnd(Expression<Func<ShadowRow, Boolean>>[])
-  nameWithType.vb: ExpressionBuilders.Predicates.LogicalAnd(Expression(Of Func(Of ShadowRow, Boolean))())
-- uid: Linq2Shadow.Utils.ExpressionBuilders.Predicates.LogicalAnd*
-  name: LogicalAnd
-  href: api/Linq2Shadow.Utils.ExpressionBuilders.Predicates.html#Linq2Shadow_Utils_ExpressionBuilders_Predicates_LogicalAnd_
-  commentId: Overload:Linq2Shadow.Utils.ExpressionBuilders.Predicates.LogicalAnd
+- uid: Linq2Shadow.Utils.ExpressionBuilders.Predicates.Or(System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}},System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}})
+  name: Or(Expression<Func<ShadowRow, Boolean>>, Expression<Func<ShadowRow, Boolean>>)
+  href: api/Linq2Shadow.Utils.ExpressionBuilders.Predicates.html#Linq2Shadow_Utils_ExpressionBuilders_Predicates_Or_System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean___System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean___
+  commentId: M:Linq2Shadow.Utils.ExpressionBuilders.Predicates.Or(System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}},System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}})
+  name.vb: Or(Expression(Of Func(Of ShadowRow, Boolean)), Expression(Of Func(Of ShadowRow, Boolean)))
+  fullName: Linq2Shadow.Utils.ExpressionBuilders.Predicates.Or(System.Linq.Expressions.Expression<System.Func<Linq2Shadow.ShadowRow, System.Boolean>>, System.Linq.Expressions.Expression<System.Func<Linq2Shadow.ShadowRow, System.Boolean>>)
+  fullName.vb: Linq2Shadow.Utils.ExpressionBuilders.Predicates.Or(System.Linq.Expressions.Expression(Of System.Func(Of Linq2Shadow.ShadowRow, System.Boolean)), System.Linq.Expressions.Expression(Of System.Func(Of Linq2Shadow.ShadowRow, System.Boolean)))
+  nameWithType: ExpressionBuilders.Predicates.Or(Expression<Func<ShadowRow, Boolean>>, Expression<Func<ShadowRow, Boolean>>)
+  nameWithType.vb: ExpressionBuilders.Predicates.Or(Expression(Of Func(Of ShadowRow, Boolean)), Expression(Of Func(Of ShadowRow, Boolean)))
+- uid: Linq2Shadow.Utils.ExpressionBuilders.Predicates.Or(System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}}[])
+  name: Or(Expression<Func<ShadowRow, Boolean>>[])
+  href: api/Linq2Shadow.Utils.ExpressionBuilders.Predicates.html#Linq2Shadow_Utils_ExpressionBuilders_Predicates_Or_System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean_____
+  commentId: M:Linq2Shadow.Utils.ExpressionBuilders.Predicates.Or(System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}}[])
+  name.vb: Or(Expression(Of Func(Of ShadowRow, Boolean))())
+  fullName: Linq2Shadow.Utils.ExpressionBuilders.Predicates.Or(System.Linq.Expressions.Expression<System.Func<Linq2Shadow.ShadowRow, System.Boolean>>[])
+  fullName.vb: Linq2Shadow.Utils.ExpressionBuilders.Predicates.Or(System.Linq.Expressions.Expression(Of System.Func(Of Linq2Shadow.ShadowRow, System.Boolean))())
+  nameWithType: ExpressionBuilders.Predicates.Or(Expression<Func<ShadowRow, Boolean>>[])
+  nameWithType.vb: ExpressionBuilders.Predicates.Or(Expression(Of Func(Of ShadowRow, Boolean))())
+- uid: Linq2Shadow.Utils.ExpressionBuilders.Predicates.Or*
+  name: Or
+  href: api/Linq2Shadow.Utils.ExpressionBuilders.Predicates.html#Linq2Shadow_Utils_ExpressionBuilders_Predicates_Or_
+  commentId: Overload:Linq2Shadow.Utils.ExpressionBuilders.Predicates.Or
   isSpec: "True"
-  fullName: Linq2Shadow.Utils.ExpressionBuilders.Predicates.LogicalAnd
-  nameWithType: ExpressionBuilders.Predicates.LogicalAnd
-- uid: Linq2Shadow.Utils.ExpressionBuilders.Predicates.LogicalOr(System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}},System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}})
-  name: LogicalOr(Expression<Func<ShadowRow, Boolean>>, Expression<Func<ShadowRow, Boolean>>)
-  href: api/Linq2Shadow.Utils.ExpressionBuilders.Predicates.html#Linq2Shadow_Utils_ExpressionBuilders_Predicates_LogicalOr_System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean___System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean___
-  commentId: M:Linq2Shadow.Utils.ExpressionBuilders.Predicates.LogicalOr(System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}},System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}})
-  name.vb: LogicalOr(Expression(Of Func(Of ShadowRow, Boolean)), Expression(Of Func(Of ShadowRow, Boolean)))
-  fullName: Linq2Shadow.Utils.ExpressionBuilders.Predicates.LogicalOr(System.Linq.Expressions.Expression<System.Func<Linq2Shadow.ShadowRow, System.Boolean>>, System.Linq.Expressions.Expression<System.Func<Linq2Shadow.ShadowRow, System.Boolean>>)
-  fullName.vb: Linq2Shadow.Utils.ExpressionBuilders.Predicates.LogicalOr(System.Linq.Expressions.Expression(Of System.Func(Of Linq2Shadow.ShadowRow, System.Boolean)), System.Linq.Expressions.Expression(Of System.Func(Of Linq2Shadow.ShadowRow, System.Boolean)))
-  nameWithType: ExpressionBuilders.Predicates.LogicalOr(Expression<Func<ShadowRow, Boolean>>, Expression<Func<ShadowRow, Boolean>>)
-  nameWithType.vb: ExpressionBuilders.Predicates.LogicalOr(Expression(Of Func(Of ShadowRow, Boolean)), Expression(Of Func(Of ShadowRow, Boolean)))
-- uid: Linq2Shadow.Utils.ExpressionBuilders.Predicates.LogicalOr(System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}}[])
-  name: LogicalOr(Expression<Func<ShadowRow, Boolean>>[])
-  href: api/Linq2Shadow.Utils.ExpressionBuilders.Predicates.html#Linq2Shadow_Utils_ExpressionBuilders_Predicates_LogicalOr_System_Linq_Expressions_Expression_System_Func_Linq2Shadow_ShadowRow_System_Boolean_____
-  commentId: M:Linq2Shadow.Utils.ExpressionBuilders.Predicates.LogicalOr(System.Linq.Expressions.Expression{System.Func{Linq2Shadow.ShadowRow,System.Boolean}}[])
-  name.vb: LogicalOr(Expression(Of Func(Of ShadowRow, Boolean))())
-  fullName: Linq2Shadow.Utils.ExpressionBuilders.Predicates.LogicalOr(System.Linq.Expressions.Expression<System.Func<Linq2Shadow.ShadowRow, System.Boolean>>[])
-  fullName.vb: Linq2Shadow.Utils.ExpressionBuilders.Predicates.LogicalOr(System.Linq.Expressions.Expression(Of System.Func(Of Linq2Shadow.ShadowRow, System.Boolean))())
-  nameWithType: ExpressionBuilders.Predicates.LogicalOr(Expression<Func<ShadowRow, Boolean>>[])
-  nameWithType.vb: ExpressionBuilders.Predicates.LogicalOr(Expression(Of Func(Of ShadowRow, Boolean))())
-- uid: Linq2Shadow.Utils.ExpressionBuilders.Predicates.LogicalOr*
-  name: LogicalOr
-  href: api/Linq2Shadow.Utils.ExpressionBuilders.Predicates.html#Linq2Shadow_Utils_ExpressionBuilders_Predicates_LogicalOr_
-  commentId: Overload:Linq2Shadow.Utils.ExpressionBuilders.Predicates.LogicalOr
-  isSpec: "True"
-  fullName: Linq2Shadow.Utils.ExpressionBuilders.Predicates.LogicalOr
-  nameWithType: ExpressionBuilders.Predicates.LogicalOr
+  fullName: Linq2Shadow.Utils.ExpressionBuilders.Predicates.Or
+  nameWithType: ExpressionBuilders.Predicates.Or
 - uid: Linq2Shadow.Utils.ExpressionBuilders.Predicates.StringContains(System.String,System.String)
   name: StringContains(String, String)
   href: api/Linq2Shadow.Utils.ExpressionBuilders.Predicates.html#Linq2Shadow_Utils_ExpressionBuilders_Predicates_StringContains_System_String_System_String_


### PR DESCRIPTION
Should close https://github.com/DDzia/Linq2Shadow/issues/45